### PR TITLE
Fixed method name when calling cdp.Send in cdpgen

### DIFF
--- a/internal/cdpgen/commands.go
+++ b/internal/cdpgen/commands.go
@@ -115,7 +115,7 @@ func generateCommands(d Domain) string {
 			fmt.Fprintf(b, "(*%sResponse, error) {\n", cmd)
 		}
 		if len(required)+len(optional) == 0 {
-			fmt.Fprintf(b, "\tresponse, err := cdp.Send(ctx, %q, nil)\n", cmd)
+			fmt.Fprintf(b, "\tresponse, err := cdp.Send(ctx, \"%s.%s\", nil)\n", d.Domain, c.Name)
 		} else {
 			fmt.Fprintln(b, "\tb, err := json.Marshal(t)")
 			fmt.Fprintln(b, "\tif err != nil {")
@@ -125,7 +125,7 @@ func generateCommands(d Domain) string {
 				fmt.Fprintln(b, "\t\treturn nil, err")
 			}
 			fmt.Fprintln(b, "\t}")
-			fmt.Fprintf(b, "\tresponse, err := cdp.Send(ctx, %q, b)\n", cmd)
+			fmt.Fprintf(b, "\tresponse, err := cdp.Send(ctx, \"%s.%s\", b)\n", d.Domain, c.Name)
 		}
 		fmt.Fprintln(b, "\tif err != nil {")
 		if len(c.Returns) == 0 {

--- a/pkg/cdp/accessibility/commands.go
+++ b/pkg/cdp/accessibility/commands.go
@@ -30,7 +30,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Accessibility.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Accessibility.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (t *GetPartialAXTree) Do(ctx context.Context) (*GetPartialAXTreeResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetPartialAXTree", b)
+	response, err := cdp.Send(ctx, "Accessibility.getPartialAXTree", b)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (t *GetFullAXTree) Do(ctx context.Context) (*GetFullAXTreeResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetFullAXTree", b)
+	response, err := cdp.Send(ctx, "Accessibility.getFullAXTree", b)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (t *GetChildAXNodes) Do(ctx context.Context) (*GetChildAXNodesResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetChildAXNodes", b)
+	response, err := cdp.Send(ctx, "Accessibility.getChildAXNodes", b)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (t *QueryAXTree) Do(ctx context.Context) (*QueryAXTreeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "QueryAXTree", b)
+	response, err := cdp.Send(ctx, "Accessibility.queryAXTree", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/animation/commands.go
+++ b/pkg/cdp/animation/commands.go
@@ -29,7 +29,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Animation.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Animation.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (t *GetCurrentTime) Do(ctx context.Context) (*GetCurrentTimeResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCurrentTime", b)
+	response, err := cdp.Send(ctx, "Animation.getCurrentTime", b)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ type GetPlaybackRateResponse struct {
 // Do sends the GetPlaybackRate CDP command to a browser,
 // and returns the browser's response.
 func (t *GetPlaybackRate) Do(ctx context.Context) (*GetPlaybackRateResponse, error) {
-	response, err := cdp.Send(ctx, "GetPlaybackRate", nil)
+	response, err := cdp.Send(ctx, "Animation.getPlaybackRate", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (t *ReleaseAnimations) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ReleaseAnimations", b)
+	response, err := cdp.Send(ctx, "Animation.releaseAnimations", b)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func (t *ResolveAnimation) Do(ctx context.Context) (*ResolveAnimationResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ResolveAnimation", b)
+	response, err := cdp.Send(ctx, "Animation.resolveAnimation", b)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (t *SeekAnimations) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SeekAnimations", b)
+	response, err := cdp.Send(ctx, "Animation.seekAnimations", b)
 	if err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func (t *SetPaused) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPaused", b)
+	response, err := cdp.Send(ctx, "Animation.setPaused", b)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func (t *SetPlaybackRate) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPlaybackRate", b)
+	response, err := cdp.Send(ctx, "Animation.setPlaybackRate", b)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (t *SetTiming) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetTiming", b)
+	response, err := cdp.Send(ctx, "Animation.setTiming", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/applicationcache/commands.go
+++ b/pkg/cdp/applicationcache/commands.go
@@ -28,7 +28,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "ApplicationCache.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (t *GetApplicationCacheForFrame) Do(ctx context.Context) (*GetApplicationCa
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetApplicationCacheForFrame", b)
+	response, err := cdp.Send(ctx, "ApplicationCache.getApplicationCacheForFrame", b)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ type GetFramesWithManifestsResponse struct {
 // Do sends the GetFramesWithManifests CDP command to a browser,
 // and returns the browser's response.
 func (t *GetFramesWithManifests) Do(ctx context.Context) (*GetFramesWithManifestsResponse, error) {
-	response, err := cdp.Send(ctx, "GetFramesWithManifests", nil)
+	response, err := cdp.Send(ctx, "ApplicationCache.getFramesWithManifests", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (t *GetManifestForFrame) Do(ctx context.Context) (*GetManifestForFrameRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetManifestForFrame", b)
+	response, err := cdp.Send(ctx, "ApplicationCache.getManifestForFrame", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/audits/commands.go
+++ b/pkg/cdp/audits/commands.go
@@ -75,7 +75,7 @@ func (t *GetEncodedResponse) Do(ctx context.Context) (*GetEncodedResponseRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetEncodedResponse", b)
+	response, err := cdp.Send(ctx, "Audits.getEncodedResponse", b)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Audits.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Audits.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (t *CheckContrast) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "CheckContrast", b)
+	response, err := cdp.Send(ctx, "Audits.checkContrast", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/backgroundservice/commands.go
+++ b/pkg/cdp/backgroundservice/commands.go
@@ -36,7 +36,7 @@ func (t *StartObserving) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartObserving", b)
+	response, err := cdp.Send(ctx, "BackgroundService.startObserving", b)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (t *StopObserving) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StopObserving", b)
+	response, err := cdp.Send(ctx, "BackgroundService.stopObserving", b)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (t *SetRecording) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetRecording", b)
+	response, err := cdp.Send(ctx, "BackgroundService.setRecording", b)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (t *ClearEvents) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ClearEvents", b)
+	response, err := cdp.Send(ctx, "BackgroundService.clearEvents", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/browser/commands.go
+++ b/pkg/cdp/browser/commands.go
@@ -66,7 +66,7 @@ func (t *SetPermission) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPermission", b)
+	response, err := cdp.Send(ctx, "Browser.setPermission", b)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (t *GrantPermissions) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "GrantPermissions", b)
+	response, err := cdp.Send(ctx, "Browser.grantPermissions", b)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (t *ResetPermissions) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ResetPermissions", b)
+	response, err := cdp.Send(ctx, "Browser.resetPermissions", b)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (t *SetDownloadBehavior) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDownloadBehavior", b)
+	response, err := cdp.Send(ctx, "Browser.setDownloadBehavior", b)
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func (t *CancelDownload) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "CancelDownload", b)
+	response, err := cdp.Send(ctx, "Browser.cancelDownload", b)
 	if err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func NewClose() *Close {
 // Do sends the Close CDP command to a browser,
 // and returns the browser's response.
 func (t *Close) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Close", nil)
+	response, err := cdp.Send(ctx, "Browser.close", nil)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func NewCrash() *Crash {
 // Do sends the Crash CDP command to a browser,
 // and returns the browser's response.
 func (t *Crash) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Crash", nil)
+	response, err := cdp.Send(ctx, "Browser.crash", nil)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func NewCrashGpuProcess() *CrashGpuProcess {
 // Do sends the CrashGpuProcess CDP command to a browser,
 // and returns the browser's response.
 func (t *CrashGpuProcess) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "CrashGpuProcess", nil)
+	response, err := cdp.Send(ctx, "Browser.crashGpuProcess", nil)
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ type GetVersionResponse struct {
 // Do sends the GetVersion CDP command to a browser,
 // and returns the browser's response.
 func (t *GetVersion) Do(ctx context.Context) (*GetVersionResponse, error) {
-	response, err := cdp.Send(ctx, "GetVersion", nil)
+	response, err := cdp.Send(ctx, "Browser.getVersion", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +503,7 @@ type GetBrowserCommandLineResponse struct {
 // Do sends the GetBrowserCommandLine CDP command to a browser,
 // and returns the browser's response.
 func (t *GetBrowserCommandLine) Do(ctx context.Context) (*GetBrowserCommandLineResponse, error) {
-	response, err := cdp.Send(ctx, "GetBrowserCommandLine", nil)
+	response, err := cdp.Send(ctx, "Browser.getBrowserCommandLine", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +579,7 @@ func (t *GetHistograms) Do(ctx context.Context) (*GetHistogramsResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetHistograms", b)
+	response, err := cdp.Send(ctx, "Browser.getHistograms", b)
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (t *GetHistogram) Do(ctx context.Context) (*GetHistogramResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetHistogram", b)
+	response, err := cdp.Send(ctx, "Browser.getHistogram", b)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +699,7 @@ func (t *GetWindowBounds) Do(ctx context.Context) (*GetWindowBoundsResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetWindowBounds", b)
+	response, err := cdp.Send(ctx, "Browser.getWindowBounds", b)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,7 @@ func (t *GetWindowForTarget) Do(ctx context.Context) (*GetWindowForTargetRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetWindowForTarget", b)
+	response, err := cdp.Send(ctx, "Browser.getWindowForTarget", b)
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +814,7 @@ func (t *SetWindowBounds) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetWindowBounds", b)
+	response, err := cdp.Send(ctx, "Browser.setWindowBounds", b)
 	if err != nil {
 		return err
 	}
@@ -872,7 +872,7 @@ func (t *SetDockTile) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDockTile", b)
+	response, err := cdp.Send(ctx, "Browser.setDockTile", b)
 	if err != nil {
 		return err
 	}
@@ -914,7 +914,7 @@ func (t *ExecuteBrowserCommand) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ExecuteBrowserCommand", b)
+	response, err := cdp.Send(ctx, "Browser.executeBrowserCommand", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/cachestorage/commands.go
+++ b/pkg/cdp/cachestorage/commands.go
@@ -37,7 +37,7 @@ func (t *DeleteCache) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeleteCache", b)
+	response, err := cdp.Send(ctx, "CacheStorage.deleteCache", b)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (t *DeleteEntry) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeleteEntry", b)
+	response, err := cdp.Send(ctx, "CacheStorage.deleteEntry", b)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (t *RequestCacheNames) Do(ctx context.Context) (*RequestCacheNamesResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestCacheNames", b)
+	response, err := cdp.Send(ctx, "CacheStorage.requestCacheNames", b)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (t *RequestCachedResponse) Do(ctx context.Context) (*RequestCachedResponseR
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestCachedResponse", b)
+	response, err := cdp.Send(ctx, "CacheStorage.requestCachedResponse", b)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (t *RequestEntries) Do(ctx context.Context) (*RequestEntriesResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestEntries", b)
+	response, err := cdp.Send(ctx, "CacheStorage.requestEntries", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/cast/commands.go
+++ b/pkg/cdp/cast/commands.go
@@ -45,7 +45,7 @@ func (t *Enable) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "Cast.enable", b)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Cast.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (t *SetSinkToUse) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetSinkToUse", b)
+	response, err := cdp.Send(ctx, "Cast.setSinkToUse", b)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (t *StartTabMirroring) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartTabMirroring", b)
+	response, err := cdp.Send(ctx, "Cast.startTabMirroring", b)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (t *StopCasting) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StopCasting", b)
+	response, err := cdp.Send(ctx, "Cast.stopCasting", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/console/commands.go
+++ b/pkg/cdp/console/commands.go
@@ -27,7 +27,7 @@ func NewClearMessages() *ClearMessages {
 // Do sends the ClearMessages CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearMessages) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearMessages", nil)
+	response, err := cdp.Send(ctx, "Console.clearMessages", nil)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Console.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Console.enable", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/css/commands.go
+++ b/pkg/cdp/css/commands.go
@@ -52,7 +52,7 @@ func (t *AddRule) Do(ctx context.Context) (*AddRuleResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AddRule", b)
+	response, err := cdp.Send(ctx, "CSS.addRule", b)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (t *CollectClassNames) Do(ctx context.Context) (*CollectClassNamesResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CollectClassNames", b)
+	response, err := cdp.Send(ctx, "CSS.collectClassNames", b)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (t *CreateStyleSheet) Do(ctx context.Context) (*CreateStyleSheetResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CreateStyleSheet", b)
+	response, err := cdp.Send(ctx, "CSS.createStyleSheet", b)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "CSS.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "CSS.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func (t *ForcePseudoState) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ForcePseudoState", b)
+	response, err := cdp.Send(ctx, "CSS.forcePseudoState", b)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (t *GetBackgroundColors) Do(ctx context.Context) (*GetBackgroundColorsRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetBackgroundColors", b)
+	response, err := cdp.Send(ctx, "CSS.getBackgroundColors", b)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (t *GetComputedStyleForNode) Do(ctx context.Context) (*GetComputedStyleForN
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetComputedStyleForNode", b)
+	response, err := cdp.Send(ctx, "CSS.getComputedStyleForNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (t *GetInlineStylesForNode) Do(ctx context.Context) (*GetInlineStylesForNod
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetInlineStylesForNode", b)
+	response, err := cdp.Send(ctx, "CSS.getInlineStylesForNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -472,7 +472,7 @@ func (t *GetMatchedStylesForNode) Do(ctx context.Context) (*GetMatchedStylesForN
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetMatchedStylesForNode", b)
+	response, err := cdp.Send(ctx, "CSS.getMatchedStylesForNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ type GetMediaQueriesResponse struct {
 // Do sends the GetMediaQueries CDP command to a browser,
 // and returns the browser's response.
 func (t *GetMediaQueries) Do(ctx context.Context) (*GetMediaQueriesResponse, error) {
-	response, err := cdp.Send(ctx, "GetMediaQueries", nil)
+	response, err := cdp.Send(ctx, "CSS.getMediaQueries", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +562,7 @@ func (t *GetPlatformFontsForNode) Do(ctx context.Context) (*GetPlatformFontsForN
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetPlatformFontsForNode", b)
+	response, err := cdp.Send(ctx, "CSS.getPlatformFontsForNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +611,7 @@ func (t *GetStyleSheetText) Do(ctx context.Context) (*GetStyleSheetTextResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetStyleSheetText", b)
+	response, err := cdp.Send(ctx, "CSS.getStyleSheetText", b)
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func (t *TrackComputedStyleUpdates) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "TrackComputedStyleUpdates", b)
+	response, err := cdp.Send(ctx, "CSS.trackComputedStyleUpdates", b)
 	if err != nil {
 		return err
 	}
@@ -703,7 +703,7 @@ type TakeComputedStyleUpdatesResponse struct {
 // Do sends the TakeComputedStyleUpdates CDP command to a browser,
 // and returns the browser's response.
 func (t *TakeComputedStyleUpdates) Do(ctx context.Context) (*TakeComputedStyleUpdatesResponse, error) {
-	response, err := cdp.Send(ctx, "TakeComputedStyleUpdates", nil)
+	response, err := cdp.Send(ctx, "CSS.takeComputedStyleUpdates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -751,7 +751,7 @@ func (t *SetEffectivePropertyValueForNode) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetEffectivePropertyValueForNode", b)
+	response, err := cdp.Send(ctx, "CSS.setEffectivePropertyValueForNode", b)
 	if err != nil {
 		return err
 	}
@@ -800,7 +800,7 @@ func (t *SetKeyframeKey) Do(ctx context.Context) (*SetKeyframeKeyResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetKeyframeKey", b)
+	response, err := cdp.Send(ctx, "CSS.setKeyframeKey", b)
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +853,7 @@ func (t *SetMediaText) Do(ctx context.Context) (*SetMediaTextResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetMediaText", b)
+	response, err := cdp.Send(ctx, "CSS.setMediaText", b)
 	if err != nil {
 		return nil, err
 	}
@@ -906,7 +906,7 @@ func (t *SetRuleSelector) Do(ctx context.Context) (*SetRuleSelectorResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetRuleSelector", b)
+	response, err := cdp.Send(ctx, "CSS.setRuleSelector", b)
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,7 @@ func (t *SetStyleSheetText) Do(ctx context.Context) (*SetStyleSheetTextResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetStyleSheetText", b)
+	response, err := cdp.Send(ctx, "CSS.setStyleSheetText", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1006,7 +1006,7 @@ func (t *SetStyleTexts) Do(ctx context.Context) (*SetStyleTextsResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetStyleTexts", b)
+	response, err := cdp.Send(ctx, "CSS.setStyleTexts", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,7 +1040,7 @@ func NewStartRuleUsageTracking() *StartRuleUsageTracking {
 // Do sends the StartRuleUsageTracking CDP command to a browser,
 // and returns the browser's response.
 func (t *StartRuleUsageTracking) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StartRuleUsageTracking", nil)
+	response, err := cdp.Send(ctx, "CSS.startRuleUsageTracking", nil)
 	if err != nil {
 		return err
 	}
@@ -1077,7 +1077,7 @@ type StopRuleUsageTrackingResponse struct {
 // Do sends the StopRuleUsageTracking CDP command to a browser,
 // and returns the browser's response.
 func (t *StopRuleUsageTracking) Do(ctx context.Context) (*StopRuleUsageTrackingResponse, error) {
-	response, err := cdp.Send(ctx, "StopRuleUsageTracking", nil)
+	response, err := cdp.Send(ctx, "CSS.stopRuleUsageTracking", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1120,7 +1120,7 @@ type TakeCoverageDeltaResponse struct {
 // Do sends the TakeCoverageDelta CDP command to a browser,
 // and returns the browser's response.
 func (t *TakeCoverageDelta) Do(ctx context.Context) (*TakeCoverageDeltaResponse, error) {
-	response, err := cdp.Send(ctx, "TakeCoverageDelta", nil)
+	response, err := cdp.Send(ctx, "CSS.takeCoverageDelta", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1167,7 +1167,7 @@ func (t *SetLocalFontsEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetLocalFontsEnabled", b)
+	response, err := cdp.Send(ctx, "CSS.setLocalFontsEnabled", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/database/commands.go
+++ b/pkg/cdp/database/commands.go
@@ -28,7 +28,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Database.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Database.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (t *ExecuteSQL) Do(ctx context.Context) (*ExecuteSQLResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ExecuteSQL", b)
+	response, err := cdp.Send(ctx, "Database.executeSQL", b)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (t *GetDatabaseTableNames) Do(ctx context.Context) (*GetDatabaseTableNamesR
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetDatabaseTableNames", b)
+	response, err := cdp.Send(ctx, "Database.getDatabaseTableNames", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/debugger/commands.go
+++ b/pkg/cdp/debugger/commands.go
@@ -46,7 +46,7 @@ func (t *ContinueToLocation) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ContinueToLocation", b)
+	response, err := cdp.Send(ctx, "Debugger.continueToLocation", b)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Debugger.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (t *Enable) Do(ctx context.Context) (*EnableResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "Debugger.enable", b)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (t *EvaluateOnCallFrame) Do(ctx context.Context) (*EvaluateOnCallFrameRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "EvaluateOnCallFrame", b)
+	response, err := cdp.Send(ctx, "Debugger.evaluateOnCallFrame", b)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func (t *GetPossibleBreakpoints) Do(ctx context.Context) (*GetPossibleBreakpoint
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetPossibleBreakpoints", b)
+	response, err := cdp.Send(ctx, "Debugger.getPossibleBreakpoints", b)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (t *GetScriptSource) Do(ctx context.Context) (*GetScriptSourceResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetScriptSource", b)
+	response, err := cdp.Send(ctx, "Debugger.getScriptSource", b)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (t *GetWasmBytecode) Do(ctx context.Context) (*GetWasmBytecodeResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetWasmBytecode", b)
+	response, err := cdp.Send(ctx, "Debugger.getWasmBytecode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (t *GetStackTrace) Do(ctx context.Context) (*GetStackTraceResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetStackTrace", b)
+	response, err := cdp.Send(ctx, "Debugger.getStackTrace", b)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +551,7 @@ func NewPause() *Pause {
 // Do sends the Pause CDP command to a browser,
 // and returns the browser's response.
 func (t *Pause) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Pause", nil)
+	response, err := cdp.Send(ctx, "Debugger.pause", nil)
 	if err != nil {
 		return err
 	}
@@ -594,7 +594,7 @@ func (t *PauseOnAsyncCall) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "PauseOnAsyncCall", b)
+	response, err := cdp.Send(ctx, "Debugger.pauseOnAsyncCall", b)
 	if err != nil {
 		return err
 	}
@@ -632,7 +632,7 @@ func (t *RemoveBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveBreakpoint", b)
+	response, err := cdp.Send(ctx, "Debugger.removeBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -684,7 +684,7 @@ func (t *RestartFrame) Do(ctx context.Context) (*RestartFrameResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RestartFrame", b)
+	response, err := cdp.Send(ctx, "Debugger.restartFrame", b)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +742,7 @@ func (t *Resume) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Resume", b)
+	response, err := cdp.Send(ctx, "Debugger.resume", b)
 	if err != nil {
 		return err
 	}
@@ -813,7 +813,7 @@ func (t *SearchInContent) Do(ctx context.Context) (*SearchInContentResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SearchInContent", b)
+	response, err := cdp.Send(ctx, "Debugger.searchInContent", b)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +857,7 @@ func (t *SetAsyncCallStackDepth) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAsyncCallStackDepth", b)
+	response, err := cdp.Send(ctx, "Debugger.setAsyncCallStackDepth", b)
 	if err != nil {
 		return err
 	}
@@ -902,7 +902,7 @@ func (t *SetBlackboxPatterns) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBlackboxPatterns", b)
+	response, err := cdp.Send(ctx, "Debugger.setBlackboxPatterns", b)
 	if err != nil {
 		return err
 	}
@@ -950,7 +950,7 @@ func (t *SetBlackboxedRanges) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBlackboxedRanges", b)
+	response, err := cdp.Send(ctx, "Debugger.setBlackboxedRanges", b)
 	if err != nil {
 		return err
 	}
@@ -1011,7 +1011,7 @@ func (t *SetBreakpoint) Do(ctx context.Context) (*SetBreakpointResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetBreakpoint", b)
+	response, err := cdp.Send(ctx, "Debugger.setBreakpoint", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1061,7 +1061,7 @@ func (t *SetInstrumentationBreakpoint) Do(ctx context.Context) (*SetInstrumentat
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetInstrumentationBreakpoint", b)
+	response, err := cdp.Send(ctx, "Debugger.setInstrumentationBreakpoint", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1175,7 +1175,7 @@ func (t *SetBreakpointByURL) Do(ctx context.Context) (*SetBreakpointByURLRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetBreakpointByURL", b)
+	response, err := cdp.Send(ctx, "Debugger.setBreakpointByUrl", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1244,7 +1244,7 @@ func (t *SetBreakpointOnFunctionCall) Do(ctx context.Context) (*SetBreakpointOnF
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetBreakpointOnFunctionCall", b)
+	response, err := cdp.Send(ctx, "Debugger.setBreakpointOnFunctionCall", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1287,7 +1287,7 @@ func (t *SetBreakpointsActive) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBreakpointsActive", b)
+	response, err := cdp.Send(ctx, "Debugger.setBreakpointsActive", b)
 	if err != nil {
 		return err
 	}
@@ -1327,7 +1327,7 @@ func (t *SetPauseOnExceptions) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPauseOnExceptions", b)
+	response, err := cdp.Send(ctx, "Debugger.setPauseOnExceptions", b)
 	if err != nil {
 		return err
 	}
@@ -1370,7 +1370,7 @@ func (t *SetReturnValue) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetReturnValue", b)
+	response, err := cdp.Send(ctx, "Debugger.setReturnValue", b)
 	if err != nil {
 		return err
 	}
@@ -1442,7 +1442,7 @@ func (t *SetScriptSource) Do(ctx context.Context) (*SetScriptSourceResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetScriptSource", b)
+	response, err := cdp.Send(ctx, "Debugger.setScriptSource", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1485,7 +1485,7 @@ func (t *SetSkipAllPauses) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetSkipAllPauses", b)
+	response, err := cdp.Send(ctx, "Debugger.setSkipAllPauses", b)
 	if err != nil {
 		return err
 	}
@@ -1535,7 +1535,7 @@ func (t *SetVariableValue) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetVariableValue", b)
+	response, err := cdp.Send(ctx, "Debugger.setVariableValue", b)
 	if err != nil {
 		return err
 	}
@@ -1602,7 +1602,7 @@ func (t *StepInto) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StepInto", b)
+	response, err := cdp.Send(ctx, "Debugger.stepInto", b)
 	if err != nil {
 		return err
 	}
@@ -1632,7 +1632,7 @@ func NewStepOut() *StepOut {
 // Do sends the StepOut CDP command to a browser,
 // and returns the browser's response.
 func (t *StepOut) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StepOut", nil)
+	response, err := cdp.Send(ctx, "Debugger.stepOut", nil)
 	if err != nil {
 		return err
 	}
@@ -1682,7 +1682,7 @@ func (t *StepOver) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StepOver", b)
+	response, err := cdp.Send(ctx, "Debugger.stepOver", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/deviceorientation/commands.go
+++ b/pkg/cdp/deviceorientation/commands.go
@@ -28,7 +28,7 @@ func NewClearDeviceOrientationOverride() *ClearDeviceOrientationOverride {
 // Do sends the ClearDeviceOrientationOverride CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearDeviceOrientationOverride) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearDeviceOrientationOverride", nil)
+	response, err := cdp.Send(ctx, "DeviceOrientation.clearDeviceOrientationOverride", nil)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (t *SetDeviceOrientationOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDeviceOrientationOverride", b)
+	response, err := cdp.Send(ctx, "DeviceOrientation.setDeviceOrientationOverride", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/dom/commands.go
+++ b/pkg/cdp/dom/commands.go
@@ -49,7 +49,7 @@ func (t *CollectClassNamesFromSubtree) Do(ctx context.Context) (*CollectClassNam
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CollectClassNamesFromSubtree", b)
+	response, err := cdp.Send(ctx, "DOM.collectClassNamesFromSubtree", b)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (t *CopyTo) Do(ctx context.Context) (*CopyToResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CopyTo", b)
+	response, err := cdp.Send(ctx, "DOM.copyTo", b)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (t *DescribeNode) Do(ctx context.Context) (*DescribeNodeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "DescribeNode", b)
+	response, err := cdp.Send(ctx, "DOM.describeNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (t *ScrollIntoViewIfNeeded) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ScrollIntoViewIfNeeded", b)
+	response, err := cdp.Send(ctx, "DOM.scrollIntoViewIfNeeded", b)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "DOM.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (t *DiscardSearchResults) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DiscardSearchResults", b)
+	response, err := cdp.Send(ctx, "DOM.discardSearchResults", b)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "DOM.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -489,7 +489,7 @@ func (t *Focus) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Focus", b)
+	response, err := cdp.Send(ctx, "DOM.focus", b)
 	if err != nil {
 		return err
 	}
@@ -535,7 +535,7 @@ func (t *GetAttributes) Do(ctx context.Context) (*GetAttributesResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetAttributes", b)
+	response, err := cdp.Send(ctx, "DOM.getAttributes", b)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (t *GetBoxModel) Do(ctx context.Context) (*GetBoxModelResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetBoxModel", b)
+	response, err := cdp.Send(ctx, "DOM.getBoxModel", b)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (t *GetContentQuads) Do(ctx context.Context) (*GetContentQuadsResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetContentQuads", b)
+	response, err := cdp.Send(ctx, "DOM.getContentQuads", b)
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +770,7 @@ func (t *GetDocument) Do(ctx context.Context) (*GetDocumentResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetDocument", b)
+	response, err := cdp.Send(ctx, "DOM.getDocument", b)
 	if err != nil {
 		return nil, err
 	}
@@ -848,7 +848,7 @@ func (t *GetFlattenedDocument) Do(ctx context.Context) (*GetFlattenedDocumentRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetFlattenedDocument", b)
+	response, err := cdp.Send(ctx, "DOM.getFlattenedDocument", b)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +918,7 @@ func (t *GetNodesForSubtreeByStyle) Do(ctx context.Context) (*GetNodesForSubtree
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetNodesForSubtreeByStyle", b)
+	response, err := cdp.Send(ctx, "DOM.getNodesForSubtreeByStyle", b)
 	if err != nil {
 		return nil, err
 	}
@@ -998,7 +998,7 @@ func (t *GetNodeForLocation) Do(ctx context.Context) (*GetNodeForLocationRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetNodeForLocation", b)
+	response, err := cdp.Send(ctx, "DOM.getNodeForLocation", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1077,7 +1077,7 @@ func (t *GetOuterHTML) Do(ctx context.Context) (*GetOuterHTMLResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetOuterHTML", b)
+	response, err := cdp.Send(ctx, "DOM.getOuterHTML", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1131,7 +1131,7 @@ func (t *GetRelayoutBoundary) Do(ctx context.Context) (*GetRelayoutBoundaryRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetRelayoutBoundary", b)
+	response, err := cdp.Send(ctx, "DOM.getRelayoutBoundary", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1192,7 +1192,7 @@ func (t *GetSearchResults) Do(ctx context.Context) (*GetSearchResultsResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetSearchResults", b)
+	response, err := cdp.Send(ctx, "DOM.getSearchResults", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1230,7 +1230,7 @@ func NewMarkUndoableState() *MarkUndoableState {
 // Do sends the MarkUndoableState CDP command to a browser,
 // and returns the browser's response.
 func (t *MarkUndoableState) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "MarkUndoableState", nil)
+	response, err := cdp.Send(ctx, "DOM.markUndoableState", nil)
 	if err != nil {
 		return err
 	}
@@ -1292,7 +1292,7 @@ func (t *MoveTo) Do(ctx context.Context) (*MoveToResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "MoveTo", b)
+	response, err := cdp.Send(ctx, "DOM.moveTo", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1360,7 +1360,7 @@ func (t *PerformSearch) Do(ctx context.Context) (*PerformSearchResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "PerformSearch", b)
+	response, err := cdp.Send(ctx, "DOM.performSearch", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1414,7 +1414,7 @@ func (t *PushNodeByPathToFrontend) Do(ctx context.Context) (*PushNodeByPathToFro
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "PushNodeByPathToFrontend", b)
+	response, err := cdp.Send(ctx, "DOM.pushNodeByPathToFrontend", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1469,7 +1469,7 @@ func (t *PushNodesByBackendIdsToFrontend) Do(ctx context.Context) (*PushNodesByB
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "PushNodesByBackendIdsToFrontend", b)
+	response, err := cdp.Send(ctx, "DOM.pushNodesByBackendIdsToFrontend", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func (t *QuerySelector) Do(ctx context.Context) (*QuerySelectorResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "QuerySelector", b)
+	response, err := cdp.Send(ctx, "DOM.querySelector", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1575,7 +1575,7 @@ func (t *QuerySelectorAll) Do(ctx context.Context) (*QuerySelectorAllResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "QuerySelectorAll", b)
+	response, err := cdp.Send(ctx, "DOM.querySelectorAll", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1613,7 +1613,7 @@ func NewRedo() *Redo {
 // Do sends the Redo CDP command to a browser,
 // and returns the browser's response.
 func (t *Redo) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Redo", nil)
+	response, err := cdp.Send(ctx, "DOM.redo", nil)
 	if err != nil {
 		return err
 	}
@@ -1655,7 +1655,7 @@ func (t *RemoveAttribute) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveAttribute", b)
+	response, err := cdp.Send(ctx, "DOM.removeAttribute", b)
 	if err != nil {
 		return err
 	}
@@ -1694,7 +1694,7 @@ func (t *RemoveNode) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveNode", b)
+	response, err := cdp.Send(ctx, "DOM.removeNode", b)
 	if err != nil {
 		return err
 	}
@@ -1761,7 +1761,7 @@ func (t *RequestChildNodes) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RequestChildNodes", b)
+	response, err := cdp.Send(ctx, "DOM.requestChildNodes", b)
 	if err != nil {
 		return err
 	}
@@ -1809,7 +1809,7 @@ func (t *RequestNode) Do(ctx context.Context) (*RequestNodeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestNode", b)
+	response, err := cdp.Send(ctx, "DOM.requestNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1899,7 +1899,7 @@ func (t *ResolveNode) Do(ctx context.Context) (*ResolveNodeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ResolveNode", b)
+	response, err := cdp.Send(ctx, "DOM.resolveNode", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1948,7 +1948,7 @@ func (t *SetAttributeValue) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAttributeValue", b)
+	response, err := cdp.Send(ctx, "DOM.setAttributeValue", b)
 	if err != nil {
 		return err
 	}
@@ -2004,7 +2004,7 @@ func (t *SetAttributesAsText) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAttributesAsText", b)
+	response, err := cdp.Send(ctx, "DOM.setAttributesAsText", b)
 	if err != nil {
 		return err
 	}
@@ -2076,7 +2076,7 @@ func (t *SetFileInputFiles) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetFileInputFiles", b)
+	response, err := cdp.Send(ctx, "DOM.setFileInputFiles", b)
 	if err != nil {
 		return err
 	}
@@ -2119,7 +2119,7 @@ func (t *SetNodeStackTracesEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetNodeStackTracesEnabled", b)
+	response, err := cdp.Send(ctx, "DOM.setNodeStackTracesEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -2169,7 +2169,7 @@ func (t *GetNodeStackTraces) Do(ctx context.Context) (*GetNodeStackTracesRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetNodeStackTraces", b)
+	response, err := cdp.Send(ctx, "DOM.getNodeStackTraces", b)
 	if err != nil {
 		return nil, err
 	}
@@ -2223,7 +2223,7 @@ func (t *GetFileInfo) Do(ctx context.Context) (*GetFileInfoResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetFileInfo", b)
+	response, err := cdp.Send(ctx, "DOM.getFileInfo", b)
 	if err != nil {
 		return nil, err
 	}
@@ -2271,7 +2271,7 @@ func (t *SetInspectedNode) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetInspectedNode", b)
+	response, err := cdp.Send(ctx, "DOM.setInspectedNode", b)
 	if err != nil {
 		return err
 	}
@@ -2320,7 +2320,7 @@ func (t *SetNodeName) Do(ctx context.Context) (*SetNodeNameResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetNodeName", b)
+	response, err := cdp.Send(ctx, "DOM.setNodeName", b)
 	if err != nil {
 		return nil, err
 	}
@@ -2366,7 +2366,7 @@ func (t *SetNodeValue) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetNodeValue", b)
+	response, err := cdp.Send(ctx, "DOM.setNodeValue", b)
 	if err != nil {
 		return err
 	}
@@ -2408,7 +2408,7 @@ func (t *SetOuterHTML) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetOuterHTML", b)
+	response, err := cdp.Send(ctx, "DOM.setOuterHTML", b)
 	if err != nil {
 		return err
 	}
@@ -2442,7 +2442,7 @@ func NewUndo() *Undo {
 // Do sends the Undo CDP command to a browser,
 // and returns the browser's response.
 func (t *Undo) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Undo", nil)
+	response, err := cdp.Send(ctx, "DOM.undo", nil)
 	if err != nil {
 		return err
 	}
@@ -2493,7 +2493,7 @@ func (t *GetFrameOwner) Do(ctx context.Context) (*GetFrameOwnerResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetFrameOwner", b)
+	response, err := cdp.Send(ctx, "DOM.getFrameOwner", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/domdebugger/commands.go
+++ b/pkg/cdp/domdebugger/commands.go
@@ -72,7 +72,7 @@ func (t *GetEventListeners) Do(ctx context.Context) (*GetEventListenersResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetEventListeners", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.getEventListeners", b)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (t *RemoveDOMBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveDOMBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.removeDOMBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (t *RemoveEventListenerBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveEventListenerBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.removeEventListenerBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func (t *RemoveInstrumentationBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveInstrumentationBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.removeInstrumentationBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func (t *RemoveXHRBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveXHRBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.removeXHRBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func (t *SetBreakOnCSPViolation) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBreakOnCSPViolation", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.setBreakOnCSPViolation", b)
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func (t *SetDOMBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDOMBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.setDOMBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (t *SetEventListenerBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetEventListenerBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.setEventListenerBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -438,7 +438,7 @@ func (t *SetInstrumentationBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetInstrumentationBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.setInstrumentationBreakpoint", b)
 	if err != nil {
 		return err
 	}
@@ -477,7 +477,7 @@ func (t *SetXHRBreakpoint) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetXHRBreakpoint", b)
+	response, err := cdp.Send(ctx, "DOMDebugger.setXHRBreakpoint", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/domsnapshot/commands.go
+++ b/pkg/cdp/domsnapshot/commands.go
@@ -28,7 +28,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "DOMSnapshot.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "DOMSnapshot.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (t *GetSnapshot) Do(ctx context.Context) (*GetSnapshotResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetSnapshot", b)
+	response, err := cdp.Send(ctx, "DOMSnapshot.getSnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (t *CaptureSnapshot) Do(ctx context.Context) (*CaptureSnapshotResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CaptureSnapshot", b)
+	response, err := cdp.Send(ctx, "DOMSnapshot.captureSnapshot", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/domstorage/commands.go
+++ b/pkg/cdp/domstorage/commands.go
@@ -34,7 +34,7 @@ func (t *Clear) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Clear", b)
+	response, err := cdp.Send(ctx, "DOMStorage.clear", b)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "DOMStorage.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "DOMStorage.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (t *GetDOMStorageItems) Do(ctx context.Context) (*GetDOMStorageItemsRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetDOMStorageItems", b)
+	response, err := cdp.Send(ctx, "DOMStorage.getDOMStorageItems", b)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (t *RemoveDOMStorageItem) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveDOMStorageItem", b)
+	response, err := cdp.Send(ctx, "DOMStorage.removeDOMStorageItem", b)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (t *SetDOMStorageItem) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDOMStorageItem", b)
+	response, err := cdp.Send(ctx, "DOMStorage.setDOMStorageItem", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/emulation/commands.go
+++ b/pkg/cdp/emulation/commands.go
@@ -37,7 +37,7 @@ type CanEmulateResponse struct {
 // Do sends the CanEmulate CDP command to a browser,
 // and returns the browser's response.
 func (t *CanEmulate) Do(ctx context.Context) (*CanEmulateResponse, error) {
-	response, err := cdp.Send(ctx, "CanEmulate", nil)
+	response, err := cdp.Send(ctx, "Emulation.canEmulate", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func NewClearDeviceMetricsOverride() *ClearDeviceMetricsOverride {
 // Do sends the ClearDeviceMetricsOverride CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearDeviceMetricsOverride) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearDeviceMetricsOverride", nil)
+	response, err := cdp.Send(ctx, "Emulation.clearDeviceMetricsOverride", nil)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func NewClearGeolocationOverride() *ClearGeolocationOverride {
 // Do sends the ClearGeolocationOverride CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearGeolocationOverride) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearGeolocationOverride", nil)
+	response, err := cdp.Send(ctx, "Emulation.clearGeolocationOverride", nil)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func NewResetPageScaleFactor() *ResetPageScaleFactor {
 // Do sends the ResetPageScaleFactor CDP command to a browser,
 // and returns the browser's response.
 func (t *ResetPageScaleFactor) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ResetPageScaleFactor", nil)
+	response, err := cdp.Send(ctx, "Emulation.resetPageScaleFactor", nil)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (t *SetFocusEmulationEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetFocusEmulationEnabled", b)
+	response, err := cdp.Send(ctx, "Emulation.setFocusEmulationEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (t *SetCPUThrottlingRate) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetCPUThrottlingRate", b)
+	response, err := cdp.Send(ctx, "Emulation.setCPUThrottlingRate", b)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func (t *SetDefaultBackgroundColorOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDefaultBackgroundColorOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setDefaultBackgroundColorOverride", b)
 	if err != nil {
 		return err
 	}
@@ -456,7 +456,7 @@ func (t *SetDeviceMetricsOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDeviceMetricsOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setDeviceMetricsOverride", b)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (t *SetScrollbarsHidden) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetScrollbarsHidden", b)
+	response, err := cdp.Send(ctx, "Emulation.setScrollbarsHidden", b)
 	if err != nil {
 		return err
 	}
@@ -538,7 +538,7 @@ func (t *SetDocumentCookieDisabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDocumentCookieDisabled", b)
+	response, err := cdp.Send(ctx, "Emulation.setDocumentCookieDisabled", b)
 	if err != nil {
 		return err
 	}
@@ -590,7 +590,7 @@ func (t *SetEmitTouchEventsForMouse) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetEmitTouchEventsForMouse", b)
+	response, err := cdp.Send(ctx, "Emulation.setEmitTouchEventsForMouse", b)
 	if err != nil {
 		return err
 	}
@@ -647,7 +647,7 @@ func (t *SetEmulatedMedia) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetEmulatedMedia", b)
+	response, err := cdp.Send(ctx, "Emulation.setEmulatedMedia", b)
 	if err != nil {
 		return err
 	}
@@ -690,7 +690,7 @@ func (t *SetEmulatedVisionDeficiency) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetEmulatedVisionDeficiency", b)
+	response, err := cdp.Send(ctx, "Emulation.setEmulatedVisionDeficiency", b)
 	if err != nil {
 		return err
 	}
@@ -759,7 +759,7 @@ func (t *SetGeolocationOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetGeolocationOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setGeolocationOverride", b)
 	if err != nil {
 		return err
 	}
@@ -805,7 +805,7 @@ func (t *SetIdleOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetIdleOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setIdleOverride", b)
 	if err != nil {
 		return err
 	}
@@ -839,7 +839,7 @@ func NewClearIdleOverride() *ClearIdleOverride {
 // Do sends the ClearIdleOverride CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearIdleOverride) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearIdleOverride", nil)
+	response, err := cdp.Send(ctx, "Emulation.clearIdleOverride", nil)
 	if err != nil {
 		return err
 	}
@@ -884,7 +884,7 @@ func (t *SetNavigatorOverrides) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetNavigatorOverrides", b)
+	response, err := cdp.Send(ctx, "Emulation.setNavigatorOverrides", b)
 	if err != nil {
 		return err
 	}
@@ -927,7 +927,7 @@ func (t *SetPageScaleFactor) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPageScaleFactor", b)
+	response, err := cdp.Send(ctx, "Emulation.setPageScaleFactor", b)
 	if err != nil {
 		return err
 	}
@@ -966,7 +966,7 @@ func (t *SetScriptExecutionDisabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetScriptExecutionDisabled", b)
+	response, err := cdp.Send(ctx, "Emulation.setScriptExecutionDisabled", b)
 	if err != nil {
 		return err
 	}
@@ -1016,7 +1016,7 @@ func (t *SetTouchEmulationEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetTouchEmulationEnabled", b)
+	response, err := cdp.Send(ctx, "Emulation.setTouchEmulationEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -1116,7 +1116,7 @@ func (t *SetVirtualTimePolicy) Do(ctx context.Context) (*SetVirtualTimePolicyRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetVirtualTimePolicy", b)
+	response, err := cdp.Send(ctx, "Emulation.setVirtualTimePolicy", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1172,7 +1172,7 @@ func (t *SetLocaleOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetLocaleOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setLocaleOverride", b)
 	if err != nil {
 		return err
 	}
@@ -1216,7 +1216,7 @@ func (t *SetTimezoneOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetTimezoneOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setTimezoneOverride", b)
 	if err != nil {
 		return err
 	}
@@ -1266,7 +1266,7 @@ func (t *SetVisibleSize) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetVisibleSize", b)
+	response, err := cdp.Send(ctx, "Emulation.setVisibleSize", b)
 	if err != nil {
 		return err
 	}
@@ -1307,7 +1307,7 @@ func (t *SetDisabledImageTypes) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDisabledImageTypes", b)
+	response, err := cdp.Send(ctx, "Emulation.setDisabledImageTypes", b)
 	if err != nil {
 		return err
 	}
@@ -1383,7 +1383,7 @@ func (t *SetUserAgentOverride) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetUserAgentOverride", b)
+	response, err := cdp.Send(ctx, "Emulation.setUserAgentOverride", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/fetch/commands.go
+++ b/pkg/cdp/fetch/commands.go
@@ -30,7 +30,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Fetch.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (t *Enable) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "Fetch.enable", b)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (t *FailRequest) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "FailRequest", b)
+	response, err := cdp.Send(ctx, "Fetch.failRequest", b)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (t *FulfillRequest) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "FulfillRequest", b)
+	response, err := cdp.Send(ctx, "Fetch.fulfillRequest", b)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func (t *ContinueRequest) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ContinueRequest", b)
+	response, err := cdp.Send(ctx, "Fetch.continueRequest", b)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (t *ContinueWithAuth) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ContinueWithAuth", b)
+	response, err := cdp.Send(ctx, "Fetch.continueWithAuth", b)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func (t *GetResponseBody) Do(ctx context.Context) (*GetResponseBodyResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetResponseBody", b)
+	response, err := cdp.Send(ctx, "Fetch.getResponseBody", b)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (t *TakeResponseBodyAsStream) Do(ctx context.Context) (*TakeResponseBodyAsS
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "TakeResponseBodyAsStream", b)
+	response, err := cdp.Send(ctx, "Fetch.takeResponseBodyAsStream", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/headlessexperimental/commands.go
+++ b/pkg/cdp/headlessexperimental/commands.go
@@ -102,7 +102,7 @@ func (t *BeginFrame) Do(ctx context.Context) (*BeginFrameResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "BeginFrame", b)
+	response, err := cdp.Send(ctx, "HeadlessExperimental.beginFrame", b)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "HeadlessExperimental.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "HeadlessExperimental.enable", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/heapprofiler/commands.go
+++ b/pkg/cdp/heapprofiler/commands.go
@@ -39,7 +39,7 @@ func (t *AddInspectedHeapObject) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "AddInspectedHeapObject", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.addInspectedHeapObject", b)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func NewCollectGarbage() *CollectGarbage {
 // Do sends the CollectGarbage CDP command to a browser,
 // and returns the browser's response.
 func (t *CollectGarbage) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "CollectGarbage", nil)
+	response, err := cdp.Send(ctx, "HeapProfiler.collectGarbage", nil)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "HeapProfiler.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "HeapProfiler.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (t *GetHeapObjectID) Do(ctx context.Context) (*GetHeapObjectIDResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetHeapObjectID", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.getHeapObjectId", b)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (t *GetObjectByHeapObjectID) Do(ctx context.Context) (*GetObjectByHeapObjec
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetObjectByHeapObjectID", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.getObjectByHeapObjectId", b)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ type GetSamplingProfileResponse struct {
 // Do sends the GetSamplingProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *GetSamplingProfile) Do(ctx context.Context) (*GetSamplingProfileResponse, error) {
-	response, err := cdp.Send(ctx, "GetSamplingProfile", nil)
+	response, err := cdp.Send(ctx, "HeapProfiler.getSamplingProfile", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (t *StartSampling) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartSampling", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.startSampling", b)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (t *StartTrackingHeapObjects) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartTrackingHeapObjects", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.startTrackingHeapObjects", b)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ type StopSamplingResponse struct {
 // Do sends the StopSampling CDP command to a browser,
 // and returns the browser's response.
 func (t *StopSampling) Do(ctx context.Context) (*StopSamplingResponse, error) {
-	response, err := cdp.Send(ctx, "StopSampling", nil)
+	response, err := cdp.Send(ctx, "HeapProfiler.stopSampling", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func (t *StopTrackingHeapObjects) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StopTrackingHeapObjects", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.stopTrackingHeapObjects", b)
 	if err != nil {
 		return err
 	}
@@ -503,7 +503,7 @@ func (t *TakeHeapSnapshot) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "TakeHeapSnapshot", b)
+	response, err := cdp.Send(ctx, "HeapProfiler.takeHeapSnapshot", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/indexeddb/commands.go
+++ b/pkg/cdp/indexeddb/commands.go
@@ -43,7 +43,7 @@ func (t *ClearObjectStore) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ClearObjectStore", b)
+	response, err := cdp.Send(ctx, "IndexedDB.clearObjectStore", b)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (t *DeleteDatabase) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeleteDatabase", b)
+	response, err := cdp.Send(ctx, "IndexedDB.deleteDatabase", b)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (t *DeleteObjectStoreEntries) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeleteObjectStoreEntries", b)
+	response, err := cdp.Send(ctx, "IndexedDB.deleteObjectStoreEntries", b)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "IndexedDB.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "IndexedDB.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func (t *RequestData) Do(ctx context.Context) (*RequestDataResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestData", b)
+	response, err := cdp.Send(ctx, "IndexedDB.requestData", b)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (t *GetMetadata) Do(ctx context.Context) (*GetMetadataResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetMetadata", b)
+	response, err := cdp.Send(ctx, "IndexedDB.getMetadata", b)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (t *RequestDatabase) Do(ctx context.Context) (*RequestDatabaseResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestDatabase", b)
+	response, err := cdp.Send(ctx, "IndexedDB.requestDatabase", b)
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +427,7 @@ func (t *RequestDatabaseNames) Do(ctx context.Context) (*RequestDatabaseNamesRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestDatabaseNames", b)
+	response, err := cdp.Send(ctx, "IndexedDB.requestDatabaseNames", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/input/commands.go
+++ b/pkg/cdp/input/commands.go
@@ -63,7 +63,7 @@ func (t *DispatchDragEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchDragEvent", b)
+	response, err := cdp.Send(ctx, "Input.dispatchDragEvent", b)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func (t *DispatchKeyEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchKeyEvent", b)
+	response, err := cdp.Send(ctx, "Input.dispatchKeyEvent", b)
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (t *InsertText) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "InsertText", b)
+	response, err := cdp.Send(ctx, "Input.insertText", b)
 	if err != nil {
 		return err
 	}
@@ -531,7 +531,7 @@ func (t *DispatchMouseEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchMouseEvent", b)
+	response, err := cdp.Send(ctx, "Input.dispatchMouseEvent", b)
 	if err != nil {
 		return err
 	}
@@ -600,7 +600,7 @@ func (t *DispatchTouchEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchTouchEvent", b)
+	response, err := cdp.Send(ctx, "Input.dispatchTouchEvent", b)
 	if err != nil {
 		return err
 	}
@@ -709,7 +709,7 @@ func (t *EmulateTouchFromMouseEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "EmulateTouchFromMouseEvent", b)
+	response, err := cdp.Send(ctx, "Input.emulateTouchFromMouseEvent", b)
 	if err != nil {
 		return err
 	}
@@ -748,7 +748,7 @@ func (t *SetIgnoreInputEvents) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetIgnoreInputEvents", b)
+	response, err := cdp.Send(ctx, "Input.setIgnoreInputEvents", b)
 	if err != nil {
 		return err
 	}
@@ -791,7 +791,7 @@ func (t *SetInterceptDrags) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetInterceptDrags", b)
+	response, err := cdp.Send(ctx, "Input.setInterceptDrags", b)
 	if err != nil {
 		return err
 	}
@@ -864,7 +864,7 @@ func (t *SynthesizePinchGesture) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SynthesizePinchGesture", b)
+	response, err := cdp.Send(ctx, "Input.synthesizePinchGesture", b)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1026,7 @@ func (t *SynthesizeScrollGesture) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SynthesizeScrollGesture", b)
+	response, err := cdp.Send(ctx, "Input.synthesizeScrollGesture", b)
 	if err != nil {
 		return err
 	}
@@ -1107,7 +1107,7 @@ func (t *SynthesizeTapGesture) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SynthesizeTapGesture", b)
+	response, err := cdp.Send(ctx, "Input.synthesizeTapGesture", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/inspector/commands.go
+++ b/pkg/cdp/inspector/commands.go
@@ -27,7 +27,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Inspector.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Inspector.enable", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/io/commands.go
+++ b/pkg/cdp/io/commands.go
@@ -38,7 +38,7 @@ func (t *Close) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Close", b)
+	response, err := cdp.Send(ctx, "IO.close", b)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (t *Read) Do(ctx context.Context) (*ReadResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "Read", b)
+	response, err := cdp.Send(ctx, "IO.read", b)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (t *ResolveBlob) Do(ctx context.Context) (*ResolveBlobResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ResolveBlob", b)
+	response, err := cdp.Send(ctx, "IO.resolveBlob", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/layertree/commands.go
+++ b/pkg/cdp/layertree/commands.go
@@ -49,7 +49,7 @@ func (t *CompositingReasons) Do(ctx context.Context) (*CompositingReasonsRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CompositingReasons", b)
+	response, err := cdp.Send(ctx, "LayerTree.compositingReasons", b)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "LayerTree.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "LayerTree.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func (t *LoadSnapshot) Do(ctx context.Context) (*LoadSnapshotResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "LoadSnapshot", b)
+	response, err := cdp.Send(ctx, "LayerTree.loadSnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (t *MakeSnapshot) Do(ctx context.Context) (*MakeSnapshotResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "MakeSnapshot", b)
+	response, err := cdp.Send(ctx, "LayerTree.makeSnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func (t *ProfileSnapshot) Do(ctx context.Context) (*ProfileSnapshotResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ProfileSnapshot", b)
+	response, err := cdp.Send(ctx, "LayerTree.profileSnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func (t *ReleaseSnapshot) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ReleaseSnapshot", b)
+	response, err := cdp.Send(ctx, "LayerTree.releaseSnapshot", b)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func (t *ReplaySnapshot) Do(ctx context.Context) (*ReplaySnapshotResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ReplaySnapshot", b)
+	response, err := cdp.Send(ctx, "LayerTree.replaySnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +462,7 @@ func (t *SnapshotCommandLog) Do(ctx context.Context) (*SnapshotCommandLogRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SnapshotCommandLog", b)
+	response, err := cdp.Send(ctx, "LayerTree.snapshotCommandLog", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/log/commands.go
+++ b/pkg/cdp/log/commands.go
@@ -28,7 +28,7 @@ func NewClear() *Clear {
 // Do sends the Clear CDP command to a browser,
 // and returns the browser's response.
 func (t *Clear) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Clear", nil)
+	response, err := cdp.Send(ctx, "Log.clear", nil)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Log.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Log.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func (t *StartViolationsReport) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartViolationsReport", b)
+	response, err := cdp.Send(ctx, "Log.startViolationsReport", b)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func NewStopViolationsReport() *StopViolationsReport {
 // Do sends the StopViolationsReport CDP command to a browser,
 // and returns the browser's response.
 func (t *StopViolationsReport) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopViolationsReport", nil)
+	response, err := cdp.Send(ctx, "Log.stopViolationsReport", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/media/commands.go
+++ b/pkg/cdp/media/commands.go
@@ -27,7 +27,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Media.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Media.disable", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/memory/commands.go
+++ b/pkg/cdp/memory/commands.go
@@ -34,7 +34,7 @@ type GetDOMCountersResponse struct {
 // Do sends the GetDOMCounters CDP command to a browser,
 // and returns the browser's response.
 func (t *GetDOMCounters) Do(ctx context.Context) (*GetDOMCountersResponse, error) {
-	response, err := cdp.Send(ctx, "GetDOMCounters", nil)
+	response, err := cdp.Send(ctx, "Memory.getDOMCounters", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func NewPrepareForLeakDetection() *PrepareForLeakDetection {
 // Do sends the PrepareForLeakDetection CDP command to a browser,
 // and returns the browser's response.
 func (t *PrepareForLeakDetection) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "PrepareForLeakDetection", nil)
+	response, err := cdp.Send(ctx, "Memory.prepareForLeakDetection", nil)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func NewForciblyPurgeJavaScriptMemory() *ForciblyPurgeJavaScriptMemory {
 // Do sends the ForciblyPurgeJavaScriptMemory CDP command to a browser,
 // and returns the browser's response.
 func (t *ForciblyPurgeJavaScriptMemory) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ForciblyPurgeJavaScriptMemory", nil)
+	response, err := cdp.Send(ctx, "Memory.forciblyPurgeJavaScriptMemory", nil)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (t *SetPressureNotificationsSuppressed) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPressureNotificationsSuppressed", b)
+	response, err := cdp.Send(ctx, "Memory.setPressureNotificationsSuppressed", b)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (t *SimulatePressureNotification) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SimulatePressureNotification", b)
+	response, err := cdp.Send(ctx, "Memory.simulatePressureNotification", b)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (t *StartSampling) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartSampling", b)
+	response, err := cdp.Send(ctx, "Memory.startSampling", b)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func NewStopSampling() *StopSampling {
 // Do sends the StopSampling CDP command to a browser,
 // and returns the browser's response.
 func (t *StopSampling) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopSampling", nil)
+	response, err := cdp.Send(ctx, "Memory.stopSampling", nil)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ type GetAllTimeSamplingProfileResponse struct {
 // Do sends the GetAllTimeSamplingProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *GetAllTimeSamplingProfile) Do(ctx context.Context) (*GetAllTimeSamplingProfileResponse, error) {
-	response, err := cdp.Send(ctx, "GetAllTimeSamplingProfile", nil)
+	response, err := cdp.Send(ctx, "Memory.getAllTimeSamplingProfile", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ type GetBrowserSamplingProfileResponse struct {
 // Do sends the GetBrowserSamplingProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *GetBrowserSamplingProfile) Do(ctx context.Context) (*GetBrowserSamplingProfileResponse, error) {
-	response, err := cdp.Send(ctx, "GetBrowserSamplingProfile", nil)
+	response, err := cdp.Send(ctx, "Memory.getBrowserSamplingProfile", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ type GetSamplingProfileResponse struct {
 // Do sends the GetSamplingProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *GetSamplingProfile) Do(ctx context.Context) (*GetSamplingProfileResponse, error) {
-	response, err := cdp.Send(ctx, "GetSamplingProfile", nil)
+	response, err := cdp.Send(ctx, "Memory.getSamplingProfile", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/network/commands.go
+++ b/pkg/cdp/network/commands.go
@@ -43,7 +43,7 @@ func (t *SetAcceptedEncodings) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAcceptedEncodings", b)
+	response, err := cdp.Send(ctx, "Network.setAcceptedEncodings", b)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func NewClearAcceptedEncodingsOverride() *ClearAcceptedEncodingsOverride {
 // Do sends the ClearAcceptedEncodingsOverride CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearAcceptedEncodingsOverride) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearAcceptedEncodingsOverride", nil)
+	response, err := cdp.Send(ctx, "Network.clearAcceptedEncodingsOverride", nil)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ type CanClearBrowserCacheResponse struct {
 // Do sends the CanClearBrowserCache CDP command to a browser,
 // and returns the browser's response.
 func (t *CanClearBrowserCache) Do(ctx context.Context) (*CanClearBrowserCacheResponse, error) {
-	response, err := cdp.Send(ctx, "CanClearBrowserCache", nil)
+	response, err := cdp.Send(ctx, "Network.canClearBrowserCache", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ type CanClearBrowserCookiesResponse struct {
 // Do sends the CanClearBrowserCookies CDP command to a browser,
 // and returns the browser's response.
 func (t *CanClearBrowserCookies) Do(ctx context.Context) (*CanClearBrowserCookiesResponse, error) {
-	response, err := cdp.Send(ctx, "CanClearBrowserCookies", nil)
+	response, err := cdp.Send(ctx, "Network.canClearBrowserCookies", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ type CanEmulateNetworkConditionsResponse struct {
 // Do sends the CanEmulateNetworkConditions CDP command to a browser,
 // and returns the browser's response.
 func (t *CanEmulateNetworkConditions) Do(ctx context.Context) (*CanEmulateNetworkConditionsResponse, error) {
-	response, err := cdp.Send(ctx, "CanEmulateNetworkConditions", nil)
+	response, err := cdp.Send(ctx, "Network.canEmulateNetworkConditions", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func NewClearBrowserCache() *ClearBrowserCache {
 // Do sends the ClearBrowserCache CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearBrowserCache) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearBrowserCache", nil)
+	response, err := cdp.Send(ctx, "Network.clearBrowserCache", nil)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func NewClearBrowserCookies() *ClearBrowserCookies {
 // Do sends the ClearBrowserCookies CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearBrowserCookies) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearBrowserCookies", nil)
+	response, err := cdp.Send(ctx, "Network.clearBrowserCookies", nil)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func (t *ContinueInterceptedRequest) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ContinueInterceptedRequest", b)
+	response, err := cdp.Send(ctx, "Network.continueInterceptedRequest", b)
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func (t *DeleteCookies) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeleteCookies", b)
+	response, err := cdp.Send(ctx, "Network.deleteCookies", b)
 	if err != nil {
 		return err
 	}
@@ -513,7 +513,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Network.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -572,7 +572,7 @@ func (t *EmulateNetworkConditions) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "EmulateNetworkConditions", b)
+	response, err := cdp.Send(ctx, "Network.emulateNetworkConditions", b)
 	if err != nil {
 		return err
 	}
@@ -648,7 +648,7 @@ func (t *Enable) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "Network.enable", b)
 	if err != nil {
 		return err
 	}
@@ -686,7 +686,7 @@ type GetAllCookiesResponse struct {
 // Do sends the GetAllCookies CDP command to a browser,
 // and returns the browser's response.
 func (t *GetAllCookies) Do(ctx context.Context) (*GetAllCookiesResponse, error) {
-	response, err := cdp.Send(ctx, "GetAllCookies", nil)
+	response, err := cdp.Send(ctx, "Network.getAllCookies", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (t *GetCertificate) Do(ctx context.Context) (*GetCertificateResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCertificate", b)
+	response, err := cdp.Send(ctx, "Network.getCertificate", b)
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +801,7 @@ func (t *GetCookies) Do(ctx context.Context) (*GetCookiesResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCookies", b)
+	response, err := cdp.Send(ctx, "Network.getCookies", b)
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +853,7 @@ func (t *GetResponseBody) Do(ctx context.Context) (*GetResponseBodyResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetResponseBody", b)
+	response, err := cdp.Send(ctx, "Network.getResponseBody", b)
 	if err != nil {
 		return nil, err
 	}
@@ -903,7 +903,7 @@ func (t *GetRequestPostData) Do(ctx context.Context) (*GetRequestPostDataRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetRequestPostData", b)
+	response, err := cdp.Send(ctx, "Network.getRequestPostData", b)
 	if err != nil {
 		return nil, err
 	}
@@ -959,7 +959,7 @@ func (t *GetResponseBodyForInterception) Do(ctx context.Context) (*GetResponseBo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetResponseBodyForInterception", b)
+	response, err := cdp.Send(ctx, "Network.getResponseBodyForInterception", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,7 +1014,7 @@ func (t *TakeResponseBodyForInterceptionAsStream) Do(ctx context.Context) (*Take
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "TakeResponseBodyForInterceptionAsStream", b)
+	response, err := cdp.Send(ctx, "Network.takeResponseBodyForInterceptionAsStream", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1063,7 +1063,7 @@ func (t *ReplayXHR) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ReplayXHR", b)
+	response, err := cdp.Send(ctx, "Network.replayXHR", b)
 	if err != nil {
 		return err
 	}
@@ -1138,7 +1138,7 @@ func (t *SearchInResponseBody) Do(ctx context.Context) (*SearchInResponseBodyRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SearchInResponseBody", b)
+	response, err := cdp.Send(ctx, "Network.searchInResponseBody", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1185,7 +1185,7 @@ func (t *SetBlockedURLs) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBlockedURLs", b)
+	response, err := cdp.Send(ctx, "Network.setBlockedURLs", b)
 	if err != nil {
 		return err
 	}
@@ -1228,7 +1228,7 @@ func (t *SetBypassServiceWorker) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBypassServiceWorker", b)
+	response, err := cdp.Send(ctx, "Network.setBypassServiceWorker", b)
 	if err != nil {
 		return err
 	}
@@ -1267,7 +1267,7 @@ func (t *SetCacheDisabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetCacheDisabled", b)
+	response, err := cdp.Send(ctx, "Network.setCacheDisabled", b)
 	if err != nil {
 		return err
 	}
@@ -1461,7 +1461,7 @@ func (t *SetCookie) Do(ctx context.Context) (*SetCookieResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SetCookie", b)
+	response, err := cdp.Send(ctx, "Network.setCookie", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1504,7 +1504,7 @@ func (t *SetCookies) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetCookies", b)
+	response, err := cdp.Send(ctx, "Network.setCookies", b)
 	if err != nil {
 		return err
 	}
@@ -1550,7 +1550,7 @@ func (t *SetDataSizeLimitsForTest) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDataSizeLimitsForTest", b)
+	response, err := cdp.Send(ctx, "Network.setDataSizeLimitsForTest", b)
 	if err != nil {
 		return err
 	}
@@ -1589,7 +1589,7 @@ func (t *SetExtraHTTPHeaders) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetExtraHTTPHeaders", b)
+	response, err := cdp.Send(ctx, "Network.setExtraHTTPHeaders", b)
 	if err != nil {
 		return err
 	}
@@ -1632,7 +1632,7 @@ func (t *SetAttachDebugStack) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAttachDebugStack", b)
+	response, err := cdp.Send(ctx, "Network.setAttachDebugStack", b)
 	if err != nil {
 		return err
 	}
@@ -1679,7 +1679,7 @@ func (t *SetRequestInterception) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetRequestInterception", b)
+	response, err := cdp.Send(ctx, "Network.setRequestInterception", b)
 	if err != nil {
 		return err
 	}
@@ -1735,7 +1735,7 @@ func (t *GetSecurityIsolationStatus) Do(ctx context.Context) (*GetSecurityIsolat
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetSecurityIsolationStatus", b)
+	response, err := cdp.Send(ctx, "Network.getSecurityIsolationStatus", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1794,7 +1794,7 @@ func (t *LoadNetworkResource) Do(ctx context.Context) (*LoadNetworkResourceRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "LoadNetworkResource", b)
+	response, err := cdp.Send(ctx, "Network.loadNetworkResource", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/overlay/commands.go
+++ b/pkg/cdp/overlay/commands.go
@@ -30,7 +30,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Overlay.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Overlay.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (t *GetHighlightObjectForTest) Do(ctx context.Context) (*GetHighlightObject
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetHighlightObjectForTest", b)
+	response, err := cdp.Send(ctx, "Overlay.getHighlightObjectForTest", b)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (t *GetGridHighlightObjectsForTest) Do(ctx context.Context) (*GetGridHighli
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetGridHighlightObjectsForTest", b)
+	response, err := cdp.Send(ctx, "Overlay.getGridHighlightObjectsForTest", b)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (t *GetSourceOrderHighlightObjectForTest) Do(ctx context.Context) (*GetSour
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetSourceOrderHighlightObjectForTest", b)
+	response, err := cdp.Send(ctx, "Overlay.getSourceOrderHighlightObjectForTest", b)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func NewHideHighlight() *HideHighlight {
 // Do sends the HideHighlight CDP command to a browser,
 // and returns the browser's response.
 func (t *HideHighlight) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "HideHighlight", nil)
+	response, err := cdp.Send(ctx, "Overlay.hideHighlight", nil)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (t *HighlightFrame) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HighlightFrame", b)
+	response, err := cdp.Send(ctx, "Overlay.highlightFrame", b)
 	if err != nil {
 		return err
 	}
@@ -429,7 +429,7 @@ func (t *HighlightNode) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HighlightNode", b)
+	response, err := cdp.Send(ctx, "Overlay.highlightNode", b)
 	if err != nil {
 		return err
 	}
@@ -490,7 +490,7 @@ func (t *HighlightQuad) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HighlightQuad", b)
+	response, err := cdp.Send(ctx, "Overlay.highlightQuad", b)
 	if err != nil {
 		return err
 	}
@@ -560,7 +560,7 @@ func (t *HighlightRect) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HighlightRect", b)
+	response, err := cdp.Send(ctx, "Overlay.highlightRect", b)
 	if err != nil {
 		return err
 	}
@@ -633,7 +633,7 @@ func (t *HighlightSourceOrder) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HighlightSourceOrder", b)
+	response, err := cdp.Send(ctx, "Overlay.highlightSourceOrder", b)
 	if err != nil {
 		return err
 	}
@@ -686,7 +686,7 @@ func (t *SetInspectMode) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetInspectMode", b)
+	response, err := cdp.Send(ctx, "Overlay.setInspectMode", b)
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (t *SetShowAdHighlights) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowAdHighlights", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowAdHighlights", b)
 	if err != nil {
 		return err
 	}
@@ -769,7 +769,7 @@ func (t *SetPausedInDebuggerMessage) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetPausedInDebuggerMessage", b)
+	response, err := cdp.Send(ctx, "Overlay.setPausedInDebuggerMessage", b)
 	if err != nil {
 		return err
 	}
@@ -808,7 +808,7 @@ func (t *SetShowDebugBorders) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowDebugBorders", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowDebugBorders", b)
 	if err != nil {
 		return err
 	}
@@ -847,7 +847,7 @@ func (t *SetShowFPSCounter) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowFPSCounter", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowFPSCounter", b)
 	if err != nil {
 		return err
 	}
@@ -886,7 +886,7 @@ func (t *SetShowGridOverlays) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowGridOverlays", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowGridOverlays", b)
 	if err != nil {
 		return err
 	}
@@ -923,7 +923,7 @@ func (t *SetShowFlexOverlays) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowFlexOverlays", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowFlexOverlays", b)
 	if err != nil {
 		return err
 	}
@@ -960,7 +960,7 @@ func (t *SetShowScrollSnapOverlays) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowScrollSnapOverlays", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowScrollSnapOverlays", b)
 	if err != nil {
 		return err
 	}
@@ -999,7 +999,7 @@ func (t *SetShowPaintRects) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowPaintRects", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowPaintRects", b)
 	if err != nil {
 		return err
 	}
@@ -1038,7 +1038,7 @@ func (t *SetShowLayoutShiftRegions) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowLayoutShiftRegions", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowLayoutShiftRegions", b)
 	if err != nil {
 		return err
 	}
@@ -1077,7 +1077,7 @@ func (t *SetShowScrollBottleneckRects) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowScrollBottleneckRects", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowScrollBottleneckRects", b)
 	if err != nil {
 		return err
 	}
@@ -1116,7 +1116,7 @@ func (t *SetShowHitTestBorders) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowHitTestBorders", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowHitTestBorders", b)
 	if err != nil {
 		return err
 	}
@@ -1154,7 +1154,7 @@ func (t *SetShowWebVitals) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowWebVitals", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowWebVitals", b)
 	if err != nil {
 		return err
 	}
@@ -1193,7 +1193,7 @@ func (t *SetShowViewportSizeOnResize) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowViewportSizeOnResize", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowViewportSizeOnResize", b)
 	if err != nil {
 		return err
 	}
@@ -1239,7 +1239,7 @@ func (t *SetShowHinge) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetShowHinge", b)
+	response, err := cdp.Send(ctx, "Overlay.setShowHinge", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/page/commands.go
+++ b/pkg/cdp/page/commands.go
@@ -54,7 +54,7 @@ func (t *AddScriptToEvaluateOnLoad) Do(ctx context.Context) (*AddScriptToEvaluat
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AddScriptToEvaluateOnLoad", b)
+	response, err := cdp.Send(ctx, "Page.addScriptToEvaluateOnLoad", b)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (t *AddScriptToEvaluateOnNewDocument) Do(ctx context.Context) (*AddScriptTo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AddScriptToEvaluateOnNewDocument", b)
+	response, err := cdp.Send(ctx, "Page.addScriptToEvaluateOnNewDocument", b)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func NewBringToFront() *BringToFront {
 // Do sends the BringToFront CDP command to a browser,
 // and returns the browser's response.
 func (t *BringToFront) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "BringToFront", nil)
+	response, err := cdp.Send(ctx, "Page.bringToFront", nil)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func (t *CaptureScreenshot) Do(ctx context.Context) (*CaptureScreenshotResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CaptureScreenshot", b)
+	response, err := cdp.Send(ctx, "Page.captureScreenshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (t *CaptureSnapshot) Do(ctx context.Context) (*CaptureSnapshotResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CaptureSnapshot", b)
+	response, err := cdp.Send(ctx, "Page.captureSnapshot", b)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (t *CreateIsolatedWorld) Do(ctx context.Context) (*CreateIsolatedWorldRespo
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CreateIsolatedWorld", b)
+	response, err := cdp.Send(ctx, "Page.createIsolatedWorld", b)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Page.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -461,7 +461,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Page.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -503,7 +503,7 @@ type GetAppManifestResponse struct {
 // Do sends the GetAppManifest CDP command to a browser,
 // and returns the browser's response.
 func (t *GetAppManifest) Do(ctx context.Context) (*GetAppManifestResponse, error) {
-	response, err := cdp.Send(ctx, "GetAppManifest", nil)
+	response, err := cdp.Send(ctx, "Page.getAppManifest", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ type GetInstallabilityErrorsResponse struct {
 // Do sends the GetInstallabilityErrors CDP command to a browser,
 // and returns the browser's response.
 func (t *GetInstallabilityErrors) Do(ctx context.Context) (*GetInstallabilityErrorsResponse, error) {
-	response, err := cdp.Send(ctx, "GetInstallabilityErrors", nil)
+	response, err := cdp.Send(ctx, "Page.getInstallabilityErrors", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +587,7 @@ type GetManifestIconsResponse struct {
 // Do sends the GetManifestIcons CDP command to a browser,
 // and returns the browser's response.
 func (t *GetManifestIcons) Do(ctx context.Context) (*GetManifestIconsResponse, error) {
-	response, err := cdp.Send(ctx, "GetManifestIcons", nil)
+	response, err := cdp.Send(ctx, "Page.getManifestIcons", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +628,7 @@ type GetFrameTreeResponse struct {
 // Do sends the GetFrameTree CDP command to a browser,
 // and returns the browser's response.
 func (t *GetFrameTree) Do(ctx context.Context) (*GetFrameTreeResponse, error) {
-	response, err := cdp.Send(ctx, "GetFrameTree", nil)
+	response, err := cdp.Send(ctx, "Page.getFrameTree", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ type GetLayoutMetricsResponse struct {
 // Do sends the GetLayoutMetrics CDP command to a browser,
 // and returns the browser's response.
 func (t *GetLayoutMetrics) Do(ctx context.Context) (*GetLayoutMetricsResponse, error) {
-	response, err := cdp.Send(ctx, "GetLayoutMetrics", nil)
+	response, err := cdp.Send(ctx, "Page.getLayoutMetrics", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +728,7 @@ type GetNavigationHistoryResponse struct {
 // Do sends the GetNavigationHistory CDP command to a browser,
 // and returns the browser's response.
 func (t *GetNavigationHistory) Do(ctx context.Context) (*GetNavigationHistoryResponse, error) {
-	response, err := cdp.Send(ctx, "GetNavigationHistory", nil)
+	response, err := cdp.Send(ctx, "Page.getNavigationHistory", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +762,7 @@ func NewResetNavigationHistory() *ResetNavigationHistory {
 // Do sends the ResetNavigationHistory CDP command to a browser,
 // and returns the browser's response.
 func (t *ResetNavigationHistory) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ResetNavigationHistory", nil)
+	response, err := cdp.Send(ctx, "Page.resetNavigationHistory", nil)
 	if err != nil {
 		return err
 	}
@@ -817,7 +817,7 @@ func (t *GetResourceContent) Do(ctx context.Context) (*GetResourceContentRespons
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetResourceContent", b)
+	response, err := cdp.Send(ctx, "Page.getResourceContent", b)
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +862,7 @@ type GetResourceTreeResponse struct {
 // Do sends the GetResourceTree CDP command to a browser,
 // and returns the browser's response.
 func (t *GetResourceTree) Do(ctx context.Context) (*GetResourceTreeResponse, error) {
-	response, err := cdp.Send(ctx, "GetResourceTree", nil)
+	response, err := cdp.Send(ctx, "Page.getResourceTree", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +918,7 @@ func (t *HandleJavaScriptDialog) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HandleJavaScriptDialog", b)
+	response, err := cdp.Send(ctx, "Page.handleJavaScriptDialog", b)
 	if err != nil {
 		return err
 	}
@@ -1016,7 +1016,7 @@ func (t *Navigate) Do(ctx context.Context) (*NavigateResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "Navigate", b)
+	response, err := cdp.Send(ctx, "Page.navigate", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1059,7 +1059,7 @@ func (t *NavigateToHistoryEntry) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "NavigateToHistoryEntry", b)
+	response, err := cdp.Send(ctx, "Page.navigateToHistoryEntry", b)
 	if err != nil {
 		return err
 	}
@@ -1307,7 +1307,7 @@ func (t *PrintToPDF) Do(ctx context.Context) (*PrintToPDFResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "PrintToPDF", b)
+	response, err := cdp.Send(ctx, "Page.printToPDF", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1370,7 +1370,7 @@ func (t *Reload) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Reload", b)
+	response, err := cdp.Send(ctx, "Page.reload", b)
 	if err != nil {
 		return err
 	}
@@ -1414,7 +1414,7 @@ func (t *RemoveScriptToEvaluateOnLoad) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveScriptToEvaluateOnLoad", b)
+	response, err := cdp.Send(ctx, "Page.removeScriptToEvaluateOnLoad", b)
 	if err != nil {
 		return err
 	}
@@ -1452,7 +1452,7 @@ func (t *RemoveScriptToEvaluateOnNewDocument) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveScriptToEvaluateOnNewDocument", b)
+	response, err := cdp.Send(ctx, "Page.removeScriptToEvaluateOnNewDocument", b)
 	if err != nil {
 		return err
 	}
@@ -1495,7 +1495,7 @@ func (t *ScreencastFrameAck) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ScreencastFrameAck", b)
+	response, err := cdp.Send(ctx, "Page.screencastFrameAck", b)
 	if err != nil {
 		return err
 	}
@@ -1573,7 +1573,7 @@ func (t *SearchInResource) Do(ctx context.Context) (*SearchInResourceResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "SearchInResource", b)
+	response, err := cdp.Send(ctx, "Page.searchInResource", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1620,7 +1620,7 @@ func (t *SetAdBlockingEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAdBlockingEnabled", b)
+	response, err := cdp.Send(ctx, "Page.setAdBlockingEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -1663,7 +1663,7 @@ func (t *SetBypassCSP) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetBypassCSP", b)
+	response, err := cdp.Send(ctx, "Page.setBypassCSP", b)
 	if err != nil {
 		return err
 	}
@@ -1711,7 +1711,7 @@ func (t *GetPermissionsPolicyState) Do(ctx context.Context) (*GetPermissionsPoli
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetPermissionsPolicyState", b)
+	response, err := cdp.Send(ctx, "Page.getPermissionsPolicyState", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1758,7 +1758,7 @@ func (t *SetFontFamilies) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetFontFamilies", b)
+	response, err := cdp.Send(ctx, "Page.setFontFamilies", b)
 	if err != nil {
 		return err
 	}
@@ -1801,7 +1801,7 @@ func (t *SetFontSizes) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetFontSizes", b)
+	response, err := cdp.Send(ctx, "Page.setFontSizes", b)
 	if err != nil {
 		return err
 	}
@@ -1843,7 +1843,7 @@ func (t *SetDocumentContent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDocumentContent", b)
+	response, err := cdp.Send(ctx, "Page.setDocumentContent", b)
 	if err != nil {
 		return err
 	}
@@ -1900,7 +1900,7 @@ func (t *SetDownloadBehavior) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDownloadBehavior", b)
+	response, err := cdp.Send(ctx, "Page.setDownloadBehavior", b)
 	if err != nil {
 		return err
 	}
@@ -1943,7 +1943,7 @@ func (t *SetLifecycleEventsEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetLifecycleEventsEnabled", b)
+	response, err := cdp.Send(ctx, "Page.setLifecycleEventsEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -2037,7 +2037,7 @@ func (t *StartScreencast) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartScreencast", b)
+	response, err := cdp.Send(ctx, "Page.startScreencast", b)
 	if err != nil {
 		return err
 	}
@@ -2067,7 +2067,7 @@ func NewStopLoading() *StopLoading {
 // Do sends the StopLoading CDP command to a browser,
 // and returns the browser's response.
 func (t *StopLoading) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopLoading", nil)
+	response, err := cdp.Send(ctx, "Page.stopLoading", nil)
 	if err != nil {
 		return err
 	}
@@ -2101,7 +2101,7 @@ func NewCrash() *Crash {
 // Do sends the Crash CDP command to a browser,
 // and returns the browser's response.
 func (t *Crash) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Crash", nil)
+	response, err := cdp.Send(ctx, "Page.crash", nil)
 	if err != nil {
 		return err
 	}
@@ -2135,7 +2135,7 @@ func NewClose() *Close {
 // Do sends the Close CDP command to a browser,
 // and returns the browser's response.
 func (t *Close) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Close", nil)
+	response, err := cdp.Send(ctx, "Page.close", nil)
 	if err != nil {
 		return err
 	}
@@ -2180,7 +2180,7 @@ func (t *SetWebLifecycleState) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetWebLifecycleState", b)
+	response, err := cdp.Send(ctx, "Page.setWebLifecycleState", b)
 	if err != nil {
 		return err
 	}
@@ -2214,7 +2214,7 @@ func NewStopScreencast() *StopScreencast {
 // Do sends the StopScreencast CDP command to a browser,
 // and returns the browser's response.
 func (t *StopScreencast) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopScreencast", nil)
+	response, err := cdp.Send(ctx, "Page.stopScreencast", nil)
 	if err != nil {
 		return err
 	}
@@ -2257,7 +2257,7 @@ func (t *SetProduceCompilationCache) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetProduceCompilationCache", b)
+	response, err := cdp.Send(ctx, "Page.setProduceCompilationCache", b)
 	if err != nil {
 		return err
 	}
@@ -2307,7 +2307,7 @@ func (t *ProduceCompilationCache) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ProduceCompilationCache", b)
+	response, err := cdp.Send(ctx, "Page.produceCompilationCache", b)
 	if err != nil {
 		return err
 	}
@@ -2353,7 +2353,7 @@ func (t *AddCompilationCache) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "AddCompilationCache", b)
+	response, err := cdp.Send(ctx, "Page.addCompilationCache", b)
 	if err != nil {
 		return err
 	}
@@ -2387,7 +2387,7 @@ func NewClearCompilationCache() *ClearCompilationCache {
 // Do sends the ClearCompilationCache CDP command to a browser,
 // and returns the browser's response.
 func (t *ClearCompilationCache) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "ClearCompilationCache", nil)
+	response, err := cdp.Send(ctx, "Page.clearCompilationCache", nil)
 	if err != nil {
 		return err
 	}
@@ -2441,7 +2441,7 @@ func (t *GenerateTestReport) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "GenerateTestReport", b)
+	response, err := cdp.Send(ctx, "Page.generateTestReport", b)
 	if err != nil {
 		return err
 	}
@@ -2475,7 +2475,7 @@ func NewWaitForDebugger() *WaitForDebugger {
 // Do sends the WaitForDebugger CDP command to a browser,
 // and returns the browser's response.
 func (t *WaitForDebugger) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "WaitForDebugger", nil)
+	response, err := cdp.Send(ctx, "Page.waitForDebugger", nil)
 	if err != nil {
 		return err
 	}
@@ -2519,7 +2519,7 @@ func (t *SetInterceptFileChooserDialog) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetInterceptFileChooserDialog", b)
+	response, err := cdp.Send(ctx, "Page.setInterceptFileChooserDialog", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/performance/commands.go
+++ b/pkg/cdp/performance/commands.go
@@ -28,7 +28,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Performance.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (t *Enable) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "Performance.enable", b)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (t *SetTimeDomain) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetTimeDomain", b)
+	response, err := cdp.Send(ctx, "Performance.setTimeDomain", b)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ type GetMetricsResponse struct {
 // Do sends the GetMetrics CDP command to a browser,
 // and returns the browser's response.
 func (t *GetMetrics) Do(ctx context.Context) (*GetMetricsResponse, error) {
-	response, err := cdp.Send(ctx, "GetMetrics", nil)
+	response, err := cdp.Send(ctx, "Performance.getMetrics", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/performancetimeline/commands.go
+++ b/pkg/cdp/performancetimeline/commands.go
@@ -42,7 +42,7 @@ func (t *Enable) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Enable", b)
+	response, err := cdp.Send(ctx, "PerformanceTimeline.enable", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/profiler/commands.go
+++ b/pkg/cdp/profiler/commands.go
@@ -26,7 +26,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Profiler.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Profiler.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ type GetBestEffortCoverageResponse struct {
 // Do sends the GetBestEffortCoverage CDP command to a browser,
 // and returns the browser's response.
 func (t *GetBestEffortCoverage) Do(ctx context.Context) (*GetBestEffortCoverageResponse, error) {
-	response, err := cdp.Send(ctx, "GetBestEffortCoverage", nil)
+	response, err := cdp.Send(ctx, "Profiler.getBestEffortCoverage", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (t *SetSamplingInterval) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetSamplingInterval", b)
+	response, err := cdp.Send(ctx, "Profiler.setSamplingInterval", b)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func NewStart() *Start {
 // Do sends the Start CDP command to a browser,
 // and returns the browser's response.
 func (t *Start) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Start", nil)
+	response, err := cdp.Send(ctx, "Profiler.start", nil)
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func (t *StartPreciseCoverage) Do(ctx context.Context) (*StartPreciseCoverageRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "StartPreciseCoverage", b)
+	response, err := cdp.Send(ctx, "Profiler.startPreciseCoverage", b)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func NewStartTypeProfile() *StartTypeProfile {
 // Do sends the StartTypeProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *StartTypeProfile) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StartTypeProfile", nil)
+	response, err := cdp.Send(ctx, "Profiler.startTypeProfile", nil)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ type StopResponse struct {
 // Do sends the Stop CDP command to a browser,
 // and returns the browser's response.
 func (t *Stop) Do(ctx context.Context) (*StopResponse, error) {
-	response, err := cdp.Send(ctx, "Stop", nil)
+	response, err := cdp.Send(ctx, "Profiler.stop", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func NewStopPreciseCoverage() *StopPreciseCoverage {
 // Do sends the StopPreciseCoverage CDP command to a browser,
 // and returns the browser's response.
 func (t *StopPreciseCoverage) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopPreciseCoverage", nil)
+	response, err := cdp.Send(ctx, "Profiler.stopPreciseCoverage", nil)
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func NewStopTypeProfile() *StopTypeProfile {
 // Do sends the StopTypeProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *StopTypeProfile) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopTypeProfile", nil)
+	response, err := cdp.Send(ctx, "Profiler.stopTypeProfile", nil)
 	if err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ type TakePreciseCoverageResponse struct {
 // Do sends the TakePreciseCoverage CDP command to a browser,
 // and returns the browser's response.
 func (t *TakePreciseCoverage) Do(ctx context.Context) (*TakePreciseCoverageResponse, error) {
-	response, err := cdp.Send(ctx, "TakePreciseCoverage", nil)
+	response, err := cdp.Send(ctx, "Profiler.takePreciseCoverage", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +467,7 @@ type TakeTypeProfileResponse struct {
 // Do sends the TakeTypeProfile CDP command to a browser,
 // and returns the browser's response.
 func (t *TakeTypeProfile) Do(ctx context.Context) (*TakeTypeProfileResponse, error) {
-	response, err := cdp.Send(ctx, "TakeTypeProfile", nil)
+	response, err := cdp.Send(ctx, "Profiler.takeTypeProfile", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func NewEnableCounters() *EnableCounters {
 // Do sends the EnableCounters CDP command to a browser,
 // and returns the browser's response.
 func (t *EnableCounters) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "EnableCounters", nil)
+	response, err := cdp.Send(ctx, "Profiler.enableCounters", nil)
 	if err != nil {
 		return err
 	}
@@ -539,7 +539,7 @@ func NewDisableCounters() *DisableCounters {
 // Do sends the DisableCounters CDP command to a browser,
 // and returns the browser's response.
 func (t *DisableCounters) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "DisableCounters", nil)
+	response, err := cdp.Send(ctx, "Profiler.disableCounters", nil)
 	if err != nil {
 		return err
 	}
@@ -580,7 +580,7 @@ type GetCountersResponse struct {
 // Do sends the GetCounters CDP command to a browser,
 // and returns the browser's response.
 func (t *GetCounters) Do(ctx context.Context) (*GetCountersResponse, error) {
-	response, err := cdp.Send(ctx, "GetCounters", nil)
+	response, err := cdp.Send(ctx, "Profiler.getCounters", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func NewEnableRuntimeCallStats() *EnableRuntimeCallStats {
 // Do sends the EnableRuntimeCallStats CDP command to a browser,
 // and returns the browser's response.
 func (t *EnableRuntimeCallStats) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "EnableRuntimeCallStats", nil)
+	response, err := cdp.Send(ctx, "Profiler.enableRuntimeCallStats", nil)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func NewDisableRuntimeCallStats() *DisableRuntimeCallStats {
 // Do sends the DisableRuntimeCallStats CDP command to a browser,
 // and returns the browser's response.
 func (t *DisableRuntimeCallStats) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "DisableRuntimeCallStats", nil)
+	response, err := cdp.Send(ctx, "Profiler.disableRuntimeCallStats", nil)
 	if err != nil {
 		return err
 	}
@@ -693,7 +693,7 @@ type GetRuntimeCallStatsResponse struct {
 // Do sends the GetRuntimeCallStats CDP command to a browser,
 // and returns the browser's response.
 func (t *GetRuntimeCallStats) Do(ctx context.Context) (*GetRuntimeCallStatsResponse, error) {
-	response, err := cdp.Send(ctx, "GetRuntimeCallStats", nil)
+	response, err := cdp.Send(ctx, "Profiler.getRuntimeCallStats", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/runtime/commands.go
+++ b/pkg/cdp/runtime/commands.go
@@ -68,7 +68,7 @@ func (t *AwaitPromise) Do(ctx context.Context) (*AwaitPromiseResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AwaitPromise", b)
+	response, err := cdp.Send(ctx, "Runtime.awaitPromise", b)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (t *CallFunctionOn) Do(ctx context.Context) (*CallFunctionOnResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CallFunctionOn", b)
+	response, err := cdp.Send(ctx, "Runtime.callFunctionOn", b)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (t *CompileScript) Do(ctx context.Context) (*CompileScriptResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CompileScript", b)
+	response, err := cdp.Send(ctx, "Runtime.compileScript", b)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Runtime.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -371,7 +371,7 @@ func NewDiscardConsoleEntries() *DiscardConsoleEntries {
 // Do sends the DiscardConsoleEntries CDP command to a browser,
 // and returns the browser's response.
 func (t *DiscardConsoleEntries) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "DiscardConsoleEntries", nil)
+	response, err := cdp.Send(ctx, "Runtime.discardConsoleEntries", nil)
 	if err != nil {
 		return err
 	}
@@ -403,7 +403,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Runtime.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -667,7 +667,7 @@ func (t *Evaluate) Do(ctx context.Context) (*EvaluateResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "Evaluate", b)
+	response, err := cdp.Send(ctx, "Runtime.evaluate", b)
 	if err != nil {
 		return nil, err
 	}
@@ -712,7 +712,7 @@ type GetIsolateIDResponse struct {
 // Do sends the GetIsolateID CDP command to a browser,
 // and returns the browser's response.
 func (t *GetIsolateID) Do(ctx context.Context) (*GetIsolateIDResponse, error) {
-	response, err := cdp.Send(ctx, "GetIsolateID", nil)
+	response, err := cdp.Send(ctx, "Runtime.getIsolateId", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +760,7 @@ type GetHeapUsageResponse struct {
 // Do sends the GetHeapUsage CDP command to a browser,
 // and returns the browser's response.
 func (t *GetHeapUsage) Do(ctx context.Context) (*GetHeapUsageResponse, error) {
-	response, err := cdp.Send(ctx, "GetHeapUsage", nil)
+	response, err := cdp.Send(ctx, "Runtime.getHeapUsage", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -864,7 +864,7 @@ func (t *GetProperties) Do(ctx context.Context) (*GetPropertiesResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetProperties", b)
+	response, err := cdp.Send(ctx, "Runtime.getProperties", b)
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +920,7 @@ func (t *GlobalLexicalScopeNames) Do(ctx context.Context) (*GlobalLexicalScopeNa
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GlobalLexicalScopeNames", b)
+	response, err := cdp.Send(ctx, "Runtime.globalLexicalScopeNames", b)
 	if err != nil {
 		return nil, err
 	}
@@ -979,7 +979,7 @@ func (t *QueryObjects) Do(ctx context.Context) (*QueryObjectsResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "QueryObjects", b)
+	response, err := cdp.Send(ctx, "Runtime.queryObjects", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1022,7 +1022,7 @@ func (t *ReleaseObject) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ReleaseObject", b)
+	response, err := cdp.Send(ctx, "Runtime.releaseObject", b)
 	if err != nil {
 		return err
 	}
@@ -1061,7 +1061,7 @@ func (t *ReleaseObjectGroup) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ReleaseObjectGroup", b)
+	response, err := cdp.Send(ctx, "Runtime.releaseObjectGroup", b)
 	if err != nil {
 		return err
 	}
@@ -1091,7 +1091,7 @@ func NewRunIfWaitingForDebugger() *RunIfWaitingForDebugger {
 // Do sends the RunIfWaitingForDebugger CDP command to a browser,
 // and returns the browser's response.
 func (t *RunIfWaitingForDebugger) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "RunIfWaitingForDebugger", nil)
+	response, err := cdp.Send(ctx, "Runtime.runIfWaitingForDebugger", nil)
 	if err != nil {
 		return err
 	}
@@ -1222,7 +1222,7 @@ func (t *RunScript) Do(ctx context.Context) (*RunScriptResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RunScript", b)
+	response, err := cdp.Send(ctx, "Runtime.runScript", b)
 	if err != nil {
 		return nil, err
 	}
@@ -1266,7 +1266,7 @@ func (t *SetCustomObjectFormatterEnabled) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetCustomObjectFormatterEnabled", b)
+	response, err := cdp.Send(ctx, "Runtime.setCustomObjectFormatterEnabled", b)
 	if err != nil {
 		return err
 	}
@@ -1306,7 +1306,7 @@ func (t *SetMaxCallStackSizeToCapture) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetMaxCallStackSizeToCapture", b)
+	response, err := cdp.Send(ctx, "Runtime.setMaxCallStackSizeToCapture", b)
 	if err != nil {
 		return err
 	}
@@ -1341,7 +1341,7 @@ func NewTerminateExecution() *TerminateExecution {
 // Do sends the TerminateExecution CDP command to a browser,
 // and returns the browser's response.
 func (t *TerminateExecution) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "TerminateExecution", nil)
+	response, err := cdp.Send(ctx, "Runtime.terminateExecution", nil)
 	if err != nil {
 		return err
 	}
@@ -1428,7 +1428,7 @@ func (t *AddBinding) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "AddBinding", b)
+	response, err := cdp.Send(ctx, "Runtime.addBinding", b)
 	if err != nil {
 		return err
 	}
@@ -1471,7 +1471,7 @@ func (t *RemoveBinding) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveBinding", b)
+	response, err := cdp.Send(ctx, "Runtime.removeBinding", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/schema/commands.go
+++ b/pkg/cdp/schema/commands.go
@@ -35,7 +35,7 @@ type GetDomainsResponse struct {
 // Do sends the GetDomains CDP command to a browser,
 // and returns the browser's response.
 func (t *GetDomains) Do(ctx context.Context) (*GetDomainsResponse, error) {
-	response, err := cdp.Send(ctx, "GetDomains", nil)
+	response, err := cdp.Send(ctx, "Schema.getDomains", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/security/commands.go
+++ b/pkg/cdp/security/commands.go
@@ -28,7 +28,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "Security.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "Security.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (t *SetIgnoreCertificateErrors) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetIgnoreCertificateErrors", b)
+	response, err := cdp.Send(ctx, "Security.setIgnoreCertificateErrors", b)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (t *HandleCertificateError) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "HandleCertificateError", b)
+	response, err := cdp.Send(ctx, "Security.handleCertificateError", b)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (t *SetOverrideCertificateErrors) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetOverrideCertificateErrors", b)
+	response, err := cdp.Send(ctx, "Security.setOverrideCertificateErrors", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/serviceworker/commands.go
+++ b/pkg/cdp/serviceworker/commands.go
@@ -38,7 +38,7 @@ func (t *DeliverPushMessage) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DeliverPushMessage", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.deliverPushMessage", b)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "ServiceWorker.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (t *DispatchSyncEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchSyncEvent", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.dispatchSyncEvent", b)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (t *DispatchPeriodicSyncEvent) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DispatchPeriodicSyncEvent", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.dispatchPeriodicSyncEvent", b)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "ServiceWorker.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (t *InspectWorker) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "InspectWorker", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.inspectWorker", b)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func (t *SetForceUpdateOnPageLoad) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetForceUpdateOnPageLoad", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.setForceUpdateOnPageLoad", b)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (t *SkipWaiting) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SkipWaiting", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.skipWaiting", b)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (t *StartWorker) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StartWorker", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.startWorker", b)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func NewStopAllWorkers() *StopAllWorkers {
 // Do sends the StopAllWorkers CDP command to a browser,
 // and returns the browser's response.
 func (t *StopAllWorkers) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "StopAllWorkers", nil)
+	response, err := cdp.Send(ctx, "ServiceWorker.stopAllWorkers", nil)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (t *StopWorker) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "StopWorker", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.stopWorker", b)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (t *Unregister) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Unregister", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.unregister", b)
 	if err != nil {
 		return err
 	}
@@ -456,7 +456,7 @@ func (t *UpdateRegistration) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "UpdateRegistration", b)
+	response, err := cdp.Send(ctx, "ServiceWorker.updateRegistration", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/storage/commands.go
+++ b/pkg/cdp/storage/commands.go
@@ -42,7 +42,7 @@ func (t *ClearDataForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ClearDataForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.clearDataForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (t *GetCookies) Do(ctx context.Context) (*GetCookiesResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCookies", b)
+	response, err := cdp.Send(ctx, "Storage.getCookies", b)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (t *SetCookies) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetCookies", b)
+	response, err := cdp.Send(ctx, "Storage.setCookies", b)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (t *ClearCookies) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ClearCookies", b)
+	response, err := cdp.Send(ctx, "Storage.clearCookies", b)
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (t *GetUsageAndQuota) Do(ctx context.Context) (*GetUsageAndQuotaResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetUsageAndQuota", b)
+	response, err := cdp.Send(ctx, "Storage.getUsageAndQuota", b)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (t *OverrideQuotaForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "OverrideQuotaForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.overrideQuotaForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (t *TrackCacheStorageForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "TrackCacheStorageForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.trackCacheStorageForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (t *TrackIndexedDBForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "TrackIndexedDBForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.trackIndexedDBForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -434,7 +434,7 @@ func (t *UntrackCacheStorageForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "UntrackCacheStorageForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.untrackCacheStorageForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func (t *UntrackIndexedDBForOrigin) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "UntrackIndexedDBForOrigin", b)
+	response, err := cdp.Send(ctx, "Storage.untrackIndexedDBForOrigin", b)
 	if err != nil {
 		return err
 	}
@@ -514,7 +514,7 @@ type GetTrustTokensResponse struct {
 // Do sends the GetTrustTokens CDP command to a browser,
 // and returns the browser's response.
 func (t *GetTrustTokens) Do(ctx context.Context) (*GetTrustTokensResponse, error) {
-	response, err := cdp.Send(ctx, "GetTrustTokens", nil)
+	response, err := cdp.Send(ctx, "Storage.getTrustTokens", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (t *ClearTrustTokens) Do(ctx context.Context) (*ClearTrustTokensResponse, e
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "ClearTrustTokens", b)
+	response, err := cdp.Send(ctx, "Storage.clearTrustTokens", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/systeminfo/commands.go
+++ b/pkg/cdp/systeminfo/commands.go
@@ -44,7 +44,7 @@ type GetInfoResponse struct {
 // Do sends the GetInfo CDP command to a browser,
 // and returns the browser's response.
 func (t *GetInfo) Do(ctx context.Context) (*GetInfoResponse, error) {
-	response, err := cdp.Send(ctx, "GetInfo", nil)
+	response, err := cdp.Send(ctx, "SystemInfo.getInfo", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ type GetProcessInfoResponse struct {
 // Do sends the GetProcessInfo CDP command to a browser,
 // and returns the browser's response.
 func (t *GetProcessInfo) Do(ctx context.Context) (*GetProcessInfoResponse, error) {
-	response, err := cdp.Send(ctx, "GetProcessInfo", nil)
+	response, err := cdp.Send(ctx, "SystemInfo.getProcessInfo", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/target/commands.go
+++ b/pkg/cdp/target/commands.go
@@ -37,7 +37,7 @@ func (t *ActivateTarget) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ActivateTarget", b)
+	response, err := cdp.Send(ctx, "Target.activateTarget", b)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (t *AttachToTarget) Do(ctx context.Context) (*AttachToTargetResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AttachToTarget", b)
+	response, err := cdp.Send(ctx, "Target.attachToTarget", b)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ type AttachToBrowserTargetResponse struct {
 // Do sends the AttachToBrowserTarget CDP command to a browser,
 // and returns the browser's response.
 func (t *AttachToBrowserTarget) Do(ctx context.Context) (*AttachToBrowserTargetResponse, error) {
-	response, err := cdp.Send(ctx, "AttachToBrowserTarget", nil)
+	response, err := cdp.Send(ctx, "Target.attachToBrowserTarget", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (t *CloseTarget) Do(ctx context.Context) (*CloseTargetResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CloseTarget", b)
+	response, err := cdp.Send(ctx, "Target.closeTarget", b)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (t *ExposeDevToolsProtocol) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ExposeDevToolsProtocol", b)
+	response, err := cdp.Send(ctx, "Target.exposeDevToolsProtocol", b)
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func (t *CreateBrowserContext) Do(ctx context.Context) (*CreateBrowserContextRes
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CreateBrowserContext", b)
+	response, err := cdp.Send(ctx, "Target.createBrowserContext", b)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ type GetBrowserContextsResponse struct {
 // Do sends the GetBrowserContexts CDP command to a browser,
 // and returns the browser's response.
 func (t *GetBrowserContexts) Do(ctx context.Context) (*GetBrowserContextsResponse, error) {
-	response, err := cdp.Send(ctx, "GetBrowserContexts", nil)
+	response, err := cdp.Send(ctx, "Target.getBrowserContexts", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +506,7 @@ func (t *CreateTarget) Do(ctx context.Context) (*CreateTargetResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "CreateTarget", b)
+	response, err := cdp.Send(ctx, "Target.createTarget", b)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +571,7 @@ func (t *DetachFromTarget) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DetachFromTarget", b)
+	response, err := cdp.Send(ctx, "Target.detachFromTarget", b)
 	if err != nil {
 		return err
 	}
@@ -614,7 +614,7 @@ func (t *DisposeBrowserContext) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "DisposeBrowserContext", b)
+	response, err := cdp.Send(ctx, "Target.disposeBrowserContext", b)
 	if err != nil {
 		return err
 	}
@@ -667,7 +667,7 @@ func (t *GetTargetInfo) Do(ctx context.Context) (*GetTargetInfoResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetTargetInfo", b)
+	response, err := cdp.Send(ctx, "Target.getTargetInfo", b)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ type GetTargetsResponse struct {
 // Do sends the GetTargets CDP command to a browser,
 // and returns the browser's response.
 func (t *GetTargets) Do(ctx context.Context) (*GetTargetsResponse, error) {
-	response, err := cdp.Send(ctx, "GetTargets", nil)
+	response, err := cdp.Send(ctx, "Target.getTargets", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +782,7 @@ func (t *SendMessageToTarget) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SendMessageToTarget", b)
+	response, err := cdp.Send(ctx, "Target.sendMessageToTarget", b)
 	if err != nil {
 		return err
 	}
@@ -846,7 +846,7 @@ func (t *SetAutoAttach) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAutoAttach", b)
+	response, err := cdp.Send(ctx, "Target.setAutoAttach", b)
 	if err != nil {
 		return err
 	}
@@ -886,7 +886,7 @@ func (t *SetDiscoverTargets) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetDiscoverTargets", b)
+	response, err := cdp.Send(ctx, "Target.setDiscoverTargets", b)
 	if err != nil {
 		return err
 	}
@@ -930,7 +930,7 @@ func (t *SetRemoteLocations) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetRemoteLocations", b)
+	response, err := cdp.Send(ctx, "Target.setRemoteLocations", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/tethering/commands.go
+++ b/pkg/cdp/tethering/commands.go
@@ -37,7 +37,7 @@ func (t *Bind) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Bind", b)
+	response, err := cdp.Send(ctx, "Tethering.bind", b)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (t *Unbind) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Unbind", b)
+	response, err := cdp.Send(ctx, "Tethering.unbind", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/tracing/commands.go
+++ b/pkg/cdp/tracing/commands.go
@@ -28,7 +28,7 @@ func NewEnd() *End {
 // Do sends the End CDP command to a browser,
 // and returns the browser's response.
 func (t *End) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "End", nil)
+	response, err := cdp.Send(ctx, "Tracing.end", nil)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ type GetCategoriesResponse struct {
 // Do sends the GetCategories CDP command to a browser,
 // and returns the browser's response.
 func (t *GetCategories) Do(ctx context.Context) (*GetCategoriesResponse, error) {
-	response, err := cdp.Send(ctx, "GetCategories", nil)
+	response, err := cdp.Send(ctx, "Tracing.getCategories", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (t *RecordClockSyncMarker) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RecordClockSyncMarker", b)
+	response, err := cdp.Send(ctx, "Tracing.recordClockSyncMarker", b)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (t *RequestMemoryDump) Do(ctx context.Context) (*RequestMemoryDumpResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "RequestMemoryDump", b)
+	response, err := cdp.Send(ctx, "Tracing.requestMemoryDump", b)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (t *Start) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "Start", b)
+	response, err := cdp.Send(ctx, "Tracing.start", b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cdp/webaudio/commands.go
+++ b/pkg/cdp/webaudio/commands.go
@@ -28,7 +28,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "WebAudio.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "WebAudio.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (t *GetRealtimeData) Do(ctx context.Context) (*GetRealtimeDataResponse, err
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetRealtimeData", b)
+	response, err := cdp.Send(ctx, "WebAudio.getRealtimeData", b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cdp/webauthn/commands.go
+++ b/pkg/cdp/webauthn/commands.go
@@ -29,7 +29,7 @@ func NewEnable() *Enable {
 // Do sends the Enable CDP command to a browser,
 // and returns the browser's response.
 func (t *Enable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Enable", nil)
+	response, err := cdp.Send(ctx, "WebAuthn.enable", nil)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func NewDisable() *Disable {
 // Do sends the Disable CDP command to a browser,
 // and returns the browser's response.
 func (t *Disable) Do(ctx context.Context) error {
-	response, err := cdp.Send(ctx, "Disable", nil)
+	response, err := cdp.Send(ctx, "WebAuthn.disable", nil)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (t *AddVirtualAuthenticator) Do(ctx context.Context) (*AddVirtualAuthentica
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "AddVirtualAuthenticator", b)
+	response, err := cdp.Send(ctx, "WebAuthn.addVirtualAuthenticator", b)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (t *RemoveVirtualAuthenticator) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveVirtualAuthenticator", b)
+	response, err := cdp.Send(ctx, "WebAuthn.removeVirtualAuthenticator", b)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (t *AddCredential) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "AddCredential", b)
+	response, err := cdp.Send(ctx, "WebAuthn.addCredential", b)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (t *GetCredential) Do(ctx context.Context) (*GetCredentialResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCredential", b)
+	response, err := cdp.Send(ctx, "WebAuthn.getCredential", b)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (t *GetCredentials) Do(ctx context.Context) (*GetCredentialsResponse, error
 	if err != nil {
 		return nil, err
 	}
-	response, err := cdp.Send(ctx, "GetCredentials", b)
+	response, err := cdp.Send(ctx, "WebAuthn.getCredentials", b)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (t *RemoveCredential) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "RemoveCredential", b)
+	response, err := cdp.Send(ctx, "WebAuthn.removeCredential", b)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func (t *ClearCredentials) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "ClearCredentials", b)
+	response, err := cdp.Send(ctx, "WebAuthn.clearCredentials", b)
 	if err != nil {
 		return err
 	}
@@ -403,7 +403,7 @@ func (t *SetUserVerified) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetUserVerified", b)
+	response, err := cdp.Send(ctx, "WebAuthn.setUserVerified", b)
 	if err != nil {
 		return err
 	}
@@ -444,7 +444,7 @@ func (t *SetAutomaticPresenceSimulation) Do(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	response, err := cdp.Send(ctx, "SetAutomaticPresenceSimulation", b)
+	response, err := cdp.Send(ctx, "WebAuthn.setAutomaticPresenceSimulation", b)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
From "Method" to "Domain.method"